### PR TITLE
Rewrite driver to official DLAB remote control protocol

### DIFF
--- a/docs/EXPERIMENT_LOG.md
+++ b/docs/EXPERIMENT_LOG.md
@@ -633,22 +633,16 @@ $130 dPette + BSS138 MOSFET ($0.10) + RP2040 ($4) + 2 solder joints.
 
 ---
 
-### FINAL CONCLUSION: Serial-only volume control is NOT possible
+### ~~FINAL CONCLUSION: Serial-only volume control is NOT possible~~
 
-After 44 experiments, every serial approach has been exhausted:
-- B3 aspirate: rejected in cal mode (every prime tried)
-- B0 in cal mode: fixed priming (b2=1/2/3 all same, payload ignored)
-- A6: changes display only, not motor travel
-- Full CMD scan: no undiscovered commands in cal mode
-- EEPROM k writes: require reboot (triggers Err4)
+**OVERTURNED by EXP-050 (2026-04-09).** Serial volume control IS possible
+using the remote control protocol (A0/B0/B2/B3) instead of the calibration
+interface (A5/A6). See EXP-049 and EXP-050 for details.
 
-**Volume-controlled aspiration requires the physical button press.**
-A6 (serial) sets the target volume, physical button triggers aspiration
-at that volume. This is a firmware design — the button GPIO ISR reads
-the A6 value, serial motor commands do not.
-
-**For automation:** servo/solenoid on button, RP2040 GPIO MitM,
-or firmware patch required.
+The original conclusion was correct within its scope — the calibration
+interface (A5/A6) does NOT provide volume control. But the remote control
+interface (B2 PI_VOLUM + B3 KEY) was never tested in the correct sequence
+because it was not discovered through PetteCali decompilation.
 
 ---
 
@@ -736,6 +730,61 @@ No bootloader detected on any baud rate.
 **Result:** No STC bootloader detected at any baud rate.
 **Conclusion:** MCU is likely NOT an STC family chip.
 Identifying the MCU requires opening the device and reading chip markings.
+
+---
+
+### EXP-049: Official DLAB remote control protocol test (2026-04-09)
+
+**Source:** Communication_Protocol_CN.doc from xg590/Learn_dPettePlus repo —
+the official DLAB serial protocol document shipped with the dPette+.
+
+**Key discovery:** The official protocol defines a completely different
+workflow from what we've been using (A5/A6 calibration interface from
+PetteCali). The remote control interface uses A0/B0/B1/B2/B3.
+
+**Device:** dPette on /dev/cu.usbserial-0001
+**Script:** `examples/test_remote_mode.py`
+**Results:**
+- A0 handshake: accepted (p1=0) — this is the REAL handshake, not A5
+- B0 param=1 (enter PI mode): accepted, motor homed
+- B1 speed control (suck=2, blow=2): both accepted
+- B2 PI_VOLUM = 200 uL (24-bit × 100 encoding): accepted (p1=0)
+- B3 param=1 (aspirate): 12-byte response, motor moved
+- B3 param=2 (dispense): 12-byte response, motor moved — FIRST TIME TESTED
+
+**Conclusion:** The entire official remote protocol works on the basic
+dPette. B3 b2=2 for dispense is confirmed working (never tested in 48
+prior experiments). B2 volume was accepted but needed volume verification.
+
+---
+
+### EXP-050: B2 volume control verification (2026-04-09)
+
+**Device:** dPette 30-300 uL, physical dial set to 300 uL
+**Script:** `examples/test_b2_volume.py`
+**Method:** Three trials — B2=50, B2=200, B2=50 — with dial fixed at 300.
+If motor travel matches B2 (not dial), volume control is confirmed.
+
+**Results:**
+- Trial 1 (B2=50 uL): motor moved, display changed to 50, SMALL aspirate
+- Trial 2 (B2=200 uL): motor moved, display changed to 200, MEDIUM aspirate
+- Trial 3 (B2=50 uL): motor moved, display changed to 50, SMALL aspirate
+
+**All three volumes matched B2 setting, NOT the 300 uL dial.**
+Display updated to show B2 volume. Liquid volumes visibly different
+between 50 and 200 uL trials.
+
+**CONCLUSION: Remote serial volume control is CONFIRMED.**
+
+The correct workflow is:
+```
+A0 (handshake) → B0 param=1 (PI mode) → B2 vol×100 (set volume) → B3 param=1 (aspirate) → B3 param=2 (dispense)
+```
+
+This overturns the EXP-044 "FINAL CONCLUSION" that serial-only volume
+control is not possible. The previous 44 experiments tested the calibration
+interface (A5/A6 from PetteCali), not the remote control interface (A0/B0/B2/B3
+from the official DLAB protocol). No MOSFET or hardware modification is needed.
 
 ---
 

--- a/docs/PROTOCOL_NOTES.md
+++ b/docs/PROTOCOL_NOTES.md
@@ -63,22 +63,23 @@ bytes (B2, B3, B4) between CMD and CHECKSUM.
 
 | CMD byte | Name             | Function in binary | Direction | Confirmed |
 |----------|------------------|--------------------|-----------|-----------|
-| `0xA5`   | HandShake        | FUN_140069c60      | host→dev  | live ✓    |
-| `0xA6`   | SendCaliVolume   | FUN_140069a10      | host→dev  | live ✓    |
-| `0xA4`   | WriteEE          | FUN_140069730      | host→dev  | live ✓    |
-| `0xA3`   | (unknown/data?)  | response handler   | host→dev  | live ✓    |
-| `0xA7`   | (unknown)        | —                  | host→dev  | live ✓    |
-| `0xA0`   | (unknown)        | —                  | host→dev  | live ✓    |
-| `0xA1`   | ReadData1        | —                  | host→dev  | live ✓    |
-| `0xA2`   | ReadData2        | —                  | host→dev  | live ✓    |
-| **`0xB0`** | **Dispense**   | —                  | host→dev  | **live ✓ motor** |
-| **`0xB3`** | **Aspirate**   | —                  | host→dev  | **live ✓ motor** |
-| `0xB1`   | (unknown flag)   | —                  | host→dev  | live ✓    |
-| `0xB2`   | (unknown flag)   | —                  | host→dev  | live ✓    |
-| `0xB4`   | (unknown flag)   | —                  | host→dev  | live ✓    |
-| `0xB5`   | (unknown flag)   | —                  | host→dev  | live ✓    |
-| `0xB6`   | (unknown flag)   | —                  | host→dev  | live ✓    |
-| `0xB7`   | (unknown flag)   | —                  | host→dev  | live ✓    |
+| `0xA0`   | **HELLO**        | —                  | host→dev  | **live ✓ EXP-049** |
+| `0xA1`   | INFO             | —                  | host→dev  | live ✓    |
+| `0xA2`   | STA              | —                  | host→dev  | live ✓    |
+| `0xA3`   | EE_READ          | response handler   | host→dev  | live ✓    |
+| `0xA4`   | EE_WRITE         | FUN_140069730      | host→dev  | live ✓    |
+| `0xA5`   | DEMARCATE        | FUN_140069c60      | host→dev  | live ✓ (cal mode) |
+| `0xA6`   | DMRCT_VOLUM      | FUN_140069a10      | host→dev  | live ✓ (cal only) |
+| `0xA7`   | RESET            | —                  | host→dev  | live ✓    |
+| `0xA8`   | DMRCT_PULSE      | —                  | host→dev  | live ✓    |
+| **`0xB0`** | **WOL (mode)** | —                  | host→dev  | **live ✓ EXP-049** |
+| **`0xB1`** | **SPEED**      | —                  | host→dev  | **live ✓ EXP-049** |
+| **`0xB2`** | **PI_VOLUM**   | —                  | host→dev  | **live ✓ EXP-050 motor** |
+| **`0xB3`** | **KEY (suck/blow)** | —             | host→dev  | **live ✓ EXP-050 motor** |
+| `0xB4`   | ST_VOLUM         | —                  | host→dev  | live ✓    |
+| `0xB5`   | ST_NUM           | —                  | host→dev  | live ✓    |
+| `0xB6`   | DI1_VOLUM        | —                  | host→dev  | live ✓    |
+| `0xB7`   | DI2_VOLUM        | —                  | host→dev  | live ✓    |
 
 CMD bytes extracted from `mov edx, 0xffffffXX` instructions immediately
 before `call rbx` (QByteArray::append) in each packet-builder function.
@@ -336,19 +337,27 @@ was confirmed on a clean device with hands completely off the pipette.
 **Volume:** determined by the physical dial setting.  There is no
 confirmed way to change the volume remotely via serial commands.
 
-### Remote volume control — NOT CONFIRMED
+### Remote volume control — CONFIRMED (EXP-050, 2026-04-09)
 
-A6 changes the display text in calibration mode, but does NOT control
-the actual motor travel.  Tested: A6=10 and A6=100 both aspirated the
-same amount.  Volume is set by the physical dial only.
+**Volume control works via the remote control protocol (B2 PI_VOLUM),
+NOT the calibration interface (A6).**
 
-Calibration mode entry (A5 b2=1) does NOT trigger motor movement by
-itself — confirmed on a clean device.  Earlier observations of motor
-movement during cal mode were caused by physical button presses to
-dismiss Err4, not by the serial command.
+The correct sequence is:
+```
+A0 (handshake) → B0 param=1 (enter PI mode) → B2 vol×100 (set volume)
+  → B3 param=1 (aspirate) → B3 param=2 (dispense)
+```
 
-**Status: remote volume control is NOT available through the known
-protocol.  Volume must be set manually on the pipette.**
+B2 encoding: volume in µL × 100, 24-bit big-endian across bytes[2:4].
+Example: 200 µL → 20000 → `[FE B2 00 4E 20 20]`
+
+Verified on dPette 30-300 µL with dial at 300: B2=50 drew ~50 µL,
+B2=200 drew ~200 µL. Display updated to show B2 volume. Motor travel
+matched B2 setting, not the physical dial.
+
+**A6 (calibration volume) does NOT control motor travel** — this remains
+true. A6 is for the PetteCali calibration workflow only. B2 is the
+correct command for runtime volume control in PI mode.
 
 ### DANGEROUS COMMANDS — DO NOT SEND
 

--- a/examples/test_b2_volume.py
+++ b/examples/test_b2_volume.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""EXP-050: B2 volume control verification — does B2 actually change motor travel?
+
+Dial stays at 300 uL. We send B2 at 50 uL then 200 uL and aspirate each.
+If both draw 300 uL worth of liquid, B2 is cosmetic only.
+If they draw visibly different amounts matching 50 and 200, volume control works.
+
+Usage:
+    python examples/test_b2_volume.py [--port /dev/cu.usbserial-0001]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+
+HEADER_TX = 0xFE
+HEADER_RX = 0xFD
+
+
+def _ck(cmd, b2, b3, b4):
+    return (cmd + b2 + b3 + b4) & 0xFF
+
+
+def _pkt(cmd, b2=0, b3=0, b4=0):
+    return bytes([HEADER_TX, cmd, b2, b3, b4, _ck(cmd, b2, b3, b4)])
+
+
+def _hex(d):
+    return d.hex(" ") if d else "(empty)"
+
+
+def _vol_b2(vol_ul):
+    v = vol_ul * 100
+    return ((v >> 16) & 0xFF, (v >> 8) & 0xFF, v & 0xFF)
+
+
+class VolumeTest:
+    def __init__(self, port, timeout=2.0):
+        import serial
+
+        self.ser = serial.Serial(
+            port=port,
+            baudrate=9600,
+            bytesize=8,
+            parity="N",
+            stopbits=1,
+            timeout=timeout,
+        )
+        self.log = logging.getLogger("EXP-050")
+
+    def close(self):
+        if self.ser and self.ser.is_open:
+            self.ser.close()
+
+    def send(self, label, pkt, read_bytes=6, pause=0.5):
+        self.log.info("--- %s ---", label)
+        self.log.info("  TX: %s", _hex(pkt))
+        self.ser.reset_input_buffer()
+        self.ser.write(pkt)
+        self.ser.flush()
+        time.sleep(pause)
+        resp = self.ser.read(read_bytes)
+        for i in range(0, len(resp), 6):
+            chunk = resp[i : i + 6]
+            self.log.info("  RX[%d]: %s", i // 6, _hex(chunk))
+        if not resp:
+            self.log.info("  RX: (no response)")
+        return resp
+
+    def drain(self):
+        leftover = self.ser.read(256)
+        if leftover:
+            self.log.info("  (drained %d bytes)", len(leftover))
+
+    def aspirate_at_volume(self, vol_ul):
+        """Send B2 to set volume, then B3 b2=1 to aspirate. Return response length."""
+        hi, mid, lo = _vol_b2(vol_ul)
+        self.log.info("")
+        self.log.info("==== ASPIRATE at B2 = %d uL (dial = 300) ====", vol_ul)
+        self.log.info(
+            "B2 encoding: %d * 100 = %d -> %02x %02x %02x",
+            vol_ul,
+            vol_ul * 100,
+            hi,
+            mid,
+            lo,
+        )
+
+        self.send(f"B2 = {vol_ul} uL", _pkt(0xB2, hi, mid, lo))
+
+        input(f">>> B2 set to {vol_ul} uL. Press Enter to aspirate...")
+
+        r = self.send(
+            f"B3 ASPIRATE (expecting {vol_ul} uL)",
+            _pkt(0xB3, 0x01),
+            read_bytes=12,
+            pause=5.0,
+        )
+        self.drain()
+
+        motor_moved = len(r) >= 12
+        self.log.info("Motor moved: %s (%d bytes)", motor_moved, len(r))
+        return motor_moved
+
+    def dispense(self):
+        """B3 b2=2 dispense."""
+        input(">>> Press Enter to dispense...")
+        self.send("B3 DISPENSE", _pkt(0xB3, 0x02), read_bytes=12, pause=5.0)
+        self.drain()
+
+    def run(self):
+        self.log.info("=" * 60)
+        self.log.info("EXP-050: B2 volume control — 50 vs 200 uL (dial at 300)")
+        self.log.info("=" * 60)
+
+        # Setup: A0 handshake + B0 PI mode
+        self.send("A0 HELLO", _pkt(0xA0))
+        self.send("B0 enter PI mode", _pkt(0xB0, 0x01), pause=2.0)
+        self.drain()
+
+        # ---- Trial 1: 50 uL ----
+        self.aspirate_at_volume(50)
+        print("\n>>> OBSERVE: Did it draw a SMALL amount (~50 uL)?")
+        print(">>>   If it drew the full 300 uL dial amount, B2 is cosmetic.\n")
+        self.dispense()
+
+        # ---- Trial 2: 200 uL ----
+        self.aspirate_at_volume(200)
+        print("\n>>> OBSERVE: Did it draw a MEDIUM amount (~200 uL)?")
+        print(">>>   Compare to trial 1. Different = B2 works!\n")
+        self.dispense()
+
+        # ---- Trial 3: 50 uL again (confirm repeatability) ----
+        self.aspirate_at_volume(50)
+        print("\n>>> OBSERVE: Same small amount as trial 1?")
+        print(">>>   If yes, B2 volume control is CONFIRMED.\n")
+        self.dispense()
+
+        self.log.info("")
+        self.log.info("=" * 60)
+        self.log.info("DONE — Three trials complete.")
+        self.log.info("  Trial 1: B2=50   (expect small)")
+        self.log.info("  Trial 2: B2=200  (expect ~4x more)")
+        self.log.info("  Trial 3: B2=50   (expect same as trial 1)")
+        self.log.info("If all three matched B2 not dial, volume control is SOLVED.")
+        self.log.info("=" * 60)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="EXP-050: B2 volume control test")
+    parser.add_argument("--port", default=None)
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s [%(levelname)-8s] %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+        handlers=[
+            logging.StreamHandler(sys.stderr),
+            logging.FileHandler("captures/exp050_b2_volume.log", mode="w"),
+        ],
+    )
+
+    port = args.port
+    if port is None:
+        from dpette.config import guess_default_port
+
+        port = guess_default_port()
+    if port is None:
+        print("ERROR: No serial port found.", file=sys.stderr)
+        sys.exit(1)
+
+    t = VolumeTest(port)
+    try:
+        t.run()
+    except KeyboardInterrupt:
+        print("\nAborted.")
+    finally:
+        t.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/test_dilution.py
+++ b/examples/test_dilution.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""EXP-053: Dilution mode test.
+
+DI mode: aspirate vol1 (diluent), aspirate vol2 (sample), switch to PI, dispense all.
+DI blow doesn't trigger the motor on the basic dPette, so we use PI mode for the dispense.
+
+Usage:
+    python examples/test_dilution.py [--port /dev/cu.usbserial-0001]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from dpette.config import SerialConfig, guess_default_port
+from dpette.driver import DPetteDriver
+from dpette.protocol import WorkingMode
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="EXP-053: Dilution mode test")
+    parser.add_argument("--port", default=None)
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s [%(levelname)-8s] %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+        handlers=[
+            logging.StreamHandler(sys.stderr),
+            logging.FileHandler("captures/exp053_dilution.log", mode="w"),
+        ],
+    )
+    log = logging.getLogger("EXP-053")
+
+    port = args.port or guess_default_port()
+    if port is None:
+        print("ERROR: No serial port found.", file=sys.stderr)
+        sys.exit(1)
+
+    cfg = SerialConfig(port=port)
+    drv = DPetteDriver(cfg)
+
+    try:
+        log.info("=" * 60)
+        log.info("EXP-053: Dilution — vol1=200 uL, vol2=100 uL")
+        log.info("=" * 60)
+
+        drv.connect()
+        log.info("Connected.\n")
+
+        log.info("Setting up DI mode (motor homes now)...")
+        drv.dilute_setup(200.0, 100.0)
+
+        input(">>> Put tip IN diluent, press Enter to aspirate vol1=200 uL...")
+        drv.dilute_aspirate()
+        log.info("First aspirate done (diluent).")
+
+        input(
+            ">>> Move tip to sample, put tip IN liquid, press Enter to aspirate vol2=100 uL..."
+        )
+        drv.dilute_aspirate()
+        log.info("Second aspirate done (sample on top).")
+
+        input(">>> RAISE tip ABOVE liquid, press Enter to dispense all...")
+        log.info("Entering PI mode — motor homes and expels liquid...")
+        drv.enter_mode(WorkingMode.PI)
+        log.info("Dispense done.")
+
+        input(">>> Done. Press Enter to finish...")
+
+    except KeyboardInterrupt:
+        print("\nAborted.")
+    finally:
+        drv.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/test_driver_modes.py
+++ b/examples/test_driver_modes.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""EXP-052: Test the new driver API — PI, ST, DI modes + mixing.
+
+Exercises every high-level method with full TX/RX logging so we can
+verify the protocol bytes match the official DLAB spec.
+
+Usage:
+    python examples/test_driver_modes.py [--port /dev/cu.usbserial-0001]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from dpette.config import SerialConfig, guess_default_port
+from dpette.driver import DPetteDriver
+from dpette.protocol import KeyAction
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="EXP-052: Driver mode tests")
+    parser.add_argument("--port", default=None)
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s [%(levelname)-8s] %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+        handlers=[
+            logging.StreamHandler(sys.stderr),
+            logging.FileHandler("captures/exp052_driver_modes.log", mode="w"),
+        ],
+    )
+    log = logging.getLogger("EXP-052")
+
+    port = args.port or guess_default_port()
+    if port is None:
+        print("ERROR: No serial port found.", file=sys.stderr)
+        sys.exit(1)
+
+    cfg = SerialConfig(port=port)
+    drv = DPetteDriver(cfg)
+
+    try:
+        # ---- Connect ----
+        log.info("=" * 60)
+        log.info("EXP-052: Full driver mode test")
+        log.info("=" * 60)
+
+        drv.connect()
+        log.info("Connected.\n")
+
+        # ---- PI mode: aspirate + dispense ----
+        log.info("=" * 60)
+        log.info("TEST 1: PI mode — aspirate 150 uL, dispense")
+        log.info("=" * 60)
+        input(">>> Tip in water, ready? Press Enter...")
+
+        pkt = drv.aspirate(150.0)
+        log.info("Aspirate result: cmd=%02x b2=%02x", pkt.cmd, pkt.b2)
+
+        input(">>> Press Enter to dispense...")
+
+        pkt = drv.dispense()
+        log.info("Dispense result: cmd=%02x b2=%02x", pkt.cmd, pkt.b2)
+
+        # ---- PI mode: change volume on the fly ----
+        log.info("")
+        log.info("=" * 60)
+        log.info("TEST 2: PI mode — aspirate 50 uL, then 250 uL")
+        log.info("=" * 60)
+        input(">>> Press Enter to aspirate 50 uL...")
+
+        drv.aspirate(50.0)
+        log.info("Aspirated 50 uL.")
+
+        input(">>> Observe small amount. Press Enter to dispense...")
+        drv.dispense()
+
+        input(">>> Press Enter to aspirate 250 uL...")
+        drv.aspirate(250.0)
+        log.info("Aspirated 250 uL.")
+
+        input(">>> Observe larger amount. Press Enter to dispense...")
+        drv.dispense()
+
+        # ---- Speed control ----
+        log.info("")
+        log.info("=" * 60)
+        log.info("TEST 3: Speed control — aspirate at speed 1 vs 3")
+        log.info("=" * 60)
+
+        drv.set_speed(KeyAction.SUCK, 1)
+        drv.set_speed(KeyAction.BLOW, 1)
+        drv.set_volume(200.0)
+
+        input(">>> Press Enter to aspirate at SLOW speed (1)...")
+        drv.aspirate()
+        log.info("Slow aspirate done.")
+
+        input(">>> Press Enter to dispense (slow)...")
+        drv.dispense()
+
+        drv.set_speed(KeyAction.SUCK, 3)
+        drv.set_speed(KeyAction.BLOW, 3)
+
+        input(">>> Press Enter to aspirate at FAST speed (3)...")
+        drv.aspirate()
+        log.info("Fast aspirate done.")
+
+        input(">>> Press Enter to dispense (fast)...")
+        drv.dispense()
+
+        # ---- Mixing ----
+        log.info("")
+        log.info("=" * 60)
+        log.info("TEST 4: Mix — 100 uL, 3 cycles, speed 3")
+        log.info("=" * 60)
+        input(">>> Tip in liquid, press Enter to mix...")
+
+        drv.mix(100.0, cycles=3, speed=3)
+        input(">>> Mix done. WITHDRAW TIP from liquid now, then press Enter...")
+        log.info("Mix complete.")
+
+        # ---- Splitting ----
+        log.info("")
+        log.info("=" * 60)
+        log.info("TEST 5: Split — 100 uL x 3 aliquots")
+        log.info("=" * 60)
+        input(">>> Tip in liquid, press Enter to start split...")
+
+        drv.split(100.0, count=3)
+        input(">>> Split done. WITHDRAW TIP from liquid now, then press Enter...")
+        log.info("Split complete.")
+
+        # ---- Dilution ----
+        log.info("")
+        log.info("=" * 60)
+        log.info("TEST 6: Dilution — vol1=200 uL, vol2=100 uL")
+        log.info("=" * 60)
+        input(">>> Tip in liquid, press Enter to start dilution...")
+
+        drv.dilute(200.0, 100.0)
+        input(">>> Dilution done. WITHDRAW TIP from liquid now, then press Enter...")
+        log.info("Dilution complete.")
+
+        # ---- Done ----
+        log.info("")
+        log.info("=" * 60)
+        log.info("ALL TESTS COMPLETE")
+        log.info("=" * 60)
+
+    except KeyboardInterrupt:
+        print("\nAborted.")
+    finally:
+        drv.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/test_driver_modes_2.py
+++ b/examples/test_driver_modes_2.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""EXP-052b: Test mix, split, and dilution modes.
+
+Continues from where test_driver_modes.py step 3 left off.
+Steps 1-3 (PI aspirate/dispense, volume switching, speed control) confirmed working.
+
+Usage:
+    python examples/test_driver_modes_2.py [--port /dev/cu.usbserial-0001]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from dpette.config import SerialConfig, guess_default_port
+from dpette.driver import DPetteDriver
+from dpette.protocol import WorkingMode
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="EXP-052b: Mix, split, dilution tests")
+    parser.add_argument("--port", default=None)
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s [%(levelname)-8s] %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+        handlers=[
+            logging.StreamHandler(sys.stderr),
+            logging.FileHandler("captures/exp052b_modes.log", mode="w"),
+        ],
+    )
+    log = logging.getLogger("EXP-052b")
+
+    port = args.port or guess_default_port()
+    if port is None:
+        print("ERROR: No serial port found.", file=sys.stderr)
+        sys.exit(1)
+
+    cfg = SerialConfig(port=port)
+    drv = DPetteDriver(cfg)
+
+    try:
+        log.info("=" * 60)
+        log.info("EXP-052b: Mix, split, dilution tests")
+        log.info("=" * 60)
+
+        drv.connect()
+        log.info("Connected (A0 + B0 PI mode).\n")
+
+        # ---- Mixing ----
+        log.info("=" * 60)
+        log.info("TEST 4: Mix — 100 uL, 3 cycles, speed 3")
+        log.info("=" * 60)
+
+        for i in range(1, 4):
+            input(f">>> Cycle {i}/3: Put tip IN liquid, press Enter to aspirate...")
+            drv.mix_aspirate(100.0, speed=3)
+            input(
+                f">>> Cycle {i}/3: RAISE tip ABOVE liquid, press Enter to dispense..."
+            )
+            drv.mix_dispense()
+            log.info("Mix cycle %d/3 complete.", i)
+
+        input(">>> Mix done. Tip in air. Press Enter to continue...\n")
+
+        # ---- Splitting ----
+        log.info("=" * 60)
+        log.info("TEST 5: Split — 100 uL x 3 aliquots")
+        log.info("=" * 60)
+        log.info("Setting up ST mode (motor homes now)...")
+        drv.split_setup(100.0, count=3)
+
+        input(">>> Put tip IN liquid, press Enter to aspirate...")
+        drv.split_aspirate()
+
+        input(">>> RAISE tip ABOVE liquid, press Enter to dispense aliquot 1...")
+        drv.split_dispense()
+
+        input(">>> Put tip IN liquid, press Enter to dispense aliquot 2...")
+        drv.split_dispense()
+
+        input(">>> Put tip IN liquid, press Enter to dispense aliquot 3...")
+        drv.split_dispense()
+
+        input(">>> Split done. Press Enter to continue...\n")
+
+        # ---- Dilution ----
+        log.info("=" * 60)
+        log.info("TEST 6: Dilution — vol1=200 uL (diluent), vol2=100 uL (sample)")
+        log.info("=" * 60)
+        log.info("Setting up DI mode (motor homes now)...")
+        drv.dilute_setup(200.0, 100.0)
+
+        input(">>> Put tip IN diluent, press Enter to aspirate vol1=200 uL...")
+        drv.dilute_aspirate()
+        log.info("First aspirate done (diluent).")
+
+        input(
+            ">>> Move tip to sample, put tip IN liquid, press Enter to aspirate vol2=100 uL..."
+        )
+        drv.dilute_aspirate()
+        log.info("Second aspirate done (sample on top of diluent).")
+
+        input(">>> RAISE tip ABOVE liquid, press Enter to dispense all...")
+        log.info("Switching to PI mode to dispense (DI blow doesn't work on dPette)...")
+        drv.enter_mode(WorkingMode.PI)
+        drv.dispense()
+        log.info("Dispense done (vol1 + vol2 together via PI blow).")
+
+        input(">>> Dilution done. Press Enter to continue...\n")
+
+        # ---- Done ----
+        log.info("=" * 60)
+        log.info("ALL TESTS COMPLETE")
+        log.info("=" * 60)
+
+    except KeyboardInterrupt:
+        print("\nAborted.")
+    finally:
+        drv.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/test_mix.py
+++ b/examples/test_mix.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""EXP-051: Mixing test — rapid aspirate/dispense cycles at max speed.
+
+Tests how fast the device can cycle B3 suck/blow in PI mode.
+Measures actual motor travel time per cycle at speed 1, 2, and 3.
+
+Usage:
+    python examples/test_mix.py [--port /dev/cu.usbserial-0001] [--volume 100] [--cycles 3]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+
+HEADER_TX = 0xFE
+HEADER_RX = 0xFD
+
+
+def _ck(cmd, b2, b3, b4):
+    return (cmd + b2 + b3 + b4) & 0xFF
+
+
+def _pkt(cmd, b2=0, b3=0, b4=0):
+    return bytes([HEADER_TX, cmd, b2, b3, b4, _ck(cmd, b2, b3, b4)])
+
+
+def _hex(d):
+    return d.hex(" ") if d else "(empty)"
+
+
+def _vol_b2(vol_ul):
+    v = vol_ul * 100
+    return ((v >> 16) & 0xFF, (v >> 8) & 0xFF, v & 0xFF)
+
+
+class MixTest:
+    def __init__(self, port, timeout=10.0):
+        import serial
+
+        self.ser = serial.Serial(
+            port=port,
+            baudrate=9600,
+            bytesize=8,
+            parity="N",
+            stopbits=1,
+            timeout=timeout,
+        )
+        self.log = logging.getLogger("EXP-051")
+
+    def close(self):
+        if self.ser and self.ser.is_open:
+            self.ser.close()
+
+    def send(self, label, pkt, read_bytes=12):
+        """Send packet, wait for full response, return (response, elapsed_seconds)."""
+        self.log.info("--- %s ---", label)
+        self.log.info("  TX: %s", _hex(pkt))
+        self.ser.reset_input_buffer()
+        t0 = time.monotonic()
+        self.ser.write(pkt)
+        self.ser.flush()
+        resp = self.ser.read(read_bytes)
+        elapsed = time.monotonic() - t0
+        for i in range(0, len(resp), 6):
+            chunk = resp[i : i + 6]
+            self.log.info("  RX[%d]: %s", i // 6, _hex(chunk))
+        if not resp:
+            self.log.info("  RX: (no response)")
+        self.log.info("  elapsed: %.2fs", elapsed)
+        return resp, elapsed
+
+    def send_short(self, label, pkt):
+        """Send packet expecting a single 6-byte ACK."""
+        self.log.info("--- %s ---", label)
+        self.log.info("  TX: %s", _hex(pkt))
+        self.ser.reset_input_buffer()
+        self.ser.write(pkt)
+        self.ser.flush()
+        time.sleep(0.3)
+        resp = self.ser.read(6)
+        if resp:
+            self.log.info("  RX: %s", _hex(resp))
+        return resp
+
+    def drain(self):
+        leftover = self.ser.read(256)
+        if leftover:
+            self.log.info("  (drained %d bytes)", len(leftover))
+
+    def mix_at_speed(self, speed, volume_ul, cycles):
+        """Run mix cycles at a given speed. Returns list of cycle times."""
+        self.log.info("")
+        self.log.info(
+            "==== MIX: speed=%d, volume=%d uL, cycles=%d ====", speed, volume_ul, cycles
+        )
+
+        # Set speed
+        self.send_short(f"B1 suck speed={speed}", _pkt(0xB1, 0x01, speed))
+        self.send_short(f"B1 blow speed={speed}", _pkt(0xB1, 0x02, speed))
+
+        # Set volume
+        hi, mid, lo = _vol_b2(volume_ul)
+        self.send_short(f"B2 = {volume_ul} uL", _pkt(0xB2, hi, mid, lo))
+
+        cycle_times = []
+        for i in range(1, cycles + 1):
+            self.log.info("")
+            self.log.info("---- Cycle %d/%d (speed=%d) ----", i, cycles, speed)
+
+            t_cycle_start = time.monotonic()
+
+            _, t_suck = self.send(f"B3 SUCK (cycle {i})", _pkt(0xB3, 0x01))
+            _, t_blow = self.send(f"B3 BLOW (cycle {i})", _pkt(0xB3, 0x02))
+
+            t_cycle = time.monotonic() - t_cycle_start
+            cycle_times.append(t_cycle)
+
+            self.log.info(
+                "  cycle %d: suck=%.2fs  blow=%.2fs  total=%.2fs",
+                i,
+                t_suck,
+                t_blow,
+                t_cycle,
+            )
+
+        avg = sum(cycle_times) / len(cycle_times) if cycle_times else 0
+        self.log.info("")
+        self.log.info(
+            "Speed %d summary: avg cycle=%.2fs, total=%.2fs for %d cycles",
+            speed,
+            avg,
+            sum(cycle_times),
+            cycles,
+        )
+        return cycle_times
+
+    def run(self, volume_ul, cycles):
+        self.log.info("=" * 60)
+        self.log.info("EXP-051: Mixing test — aspirate/dispense cycle timing")
+        self.log.info("Volume: %d uL  |  Cycles per speed: %d", volume_ul, cycles)
+        self.log.info("=" * 60)
+
+        # Setup
+        self.send_short("A0 HELLO", _pkt(0xA0))
+        r, _ = self.send("B0 enter PI mode", _pkt(0xB0, 0x01))
+        self.drain()
+
+        input(">>> Tip in liquid and ready? Press Enter to start mixing...")
+
+        all_results = {}
+        for speed in [1, 2, 3]:
+            times = self.mix_at_speed(speed, volume_ul, cycles)
+            all_results[speed] = times
+
+            if speed < 3:
+                input(f">>> Speed {speed} done. Press Enter for speed {speed+1}...")
+
+        # Summary
+        self.log.info("")
+        self.log.info("=" * 60)
+        self.log.info("TIMING SUMMARY")
+        self.log.info("=" * 60)
+        self.log.info(
+            "%-8s  %-12s  %-12s  %s", "Speed", "Avg cycle", "Total", "Per-cycle"
+        )
+        for speed, times in all_results.items():
+            avg = sum(times) / len(times)
+            detail = ", ".join(f"{t:.2f}s" for t in times)
+            self.log.info(
+                "%-8d  %-12.2fs  %-12.2fs  %s", speed, avg, sum(times), detail
+            )
+
+        fastest = min(all_results.items(), key=lambda x: sum(x[1]) / len(x[1]))
+        self.log.info("")
+        self.log.info(
+            "Fastest: speed=%d at %.2fs/cycle",
+            fastest[0],
+            sum(fastest[1]) / len(fastest[1]),
+        )
+        self.log.info(
+            "A %d-cycle mix at speed %d takes ~%.1fs total",
+            cycles,
+            fastest[0],
+            sum(fastest[1]),
+        )
+        self.log.info("=" * 60)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="EXP-051: Mixing cycle timing test")
+    parser.add_argument("--port", default=None)
+    parser.add_argument(
+        "--volume", type=int, default=100, help="Mix volume in uL (default: 100)"
+    )
+    parser.add_argument(
+        "--cycles", type=int, default=3, help="Cycles per speed level (default: 3)"
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s [%(levelname)-8s] %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+        handlers=[
+            logging.StreamHandler(sys.stderr),
+            logging.FileHandler("captures/exp051_mix.log", mode="w"),
+        ],
+    )
+
+    port = args.port
+    if port is None:
+        from dpette.config import guess_default_port
+
+        port = guess_default_port()
+    if port is None:
+        print("ERROR: No serial port found.", file=sys.stderr)
+        sys.exit(1)
+
+    t = MixTest(port)
+    try:
+        t.run(volume_ul=args.volume, cycles=args.cycles)
+    except KeyboardInterrupt:
+        print("\nAborted.")
+    finally:
+        t.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/test_remote_mode.py
+++ b/examples/test_remote_mode.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""EXP-049: Test the official DLAB remote control protocol.
+
+The official Communication_Protocol_CN.doc (from xg590/Learn_dPettePlus)
+reveals a completely different workflow from what we've been using:
+
+  Our flow:     A5 (handshake) -> B0 b2=1 (dispense) -> B3 b2=1 (aspirate)
+  Official:     A0 (handshake) -> B0 b2=1 (enter PI mode) -> B2 (set vol) -> B3 b2=1/2 (suck/blow)
+
+Key differences:
+  - A0 is the real handshake (not A5, which is calibration mode entry)
+  - B0 param=1 is "enter PI (pipetting) mode", not "dispense"
+  - B2 sets pipetting volume (24-bit big-endian, volume * 100)
+  - B3 b2=2 is dispense (we never tried this!)
+
+This script tests the full official protocol sequence and logs every
+byte exchanged, so we can see exactly what the device supports.
+
+Usage:
+    python examples/test_remote_mode.py [--port /dev/cu.usbserial-0001]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+
+# -- minimal protocol helpers (no dependency on dpette.protocol) -----------
+# We define these inline so the script is self-contained and we can test
+# encodings that differ from the existing driver.
+
+HEADER_TX = 0xFE
+HEADER_RX = 0xFD
+
+
+def _cksum(cmd: int, b2: int, b3: int, b4: int) -> int:
+    return (cmd + b2 + b3 + b4) & 0xFF
+
+
+def _pkt(cmd: int, b2: int = 0, b3: int = 0, b4: int = 0) -> bytes:
+    return bytes([HEADER_TX, cmd, b2, b3, b4, _cksum(cmd, b2, b3, b4)])
+
+
+def _hex(data: bytes) -> str:
+    return data.hex(" ") if data else "(empty)"
+
+
+def _desc_rx(data: bytes) -> str:
+    """Describe a 6-byte response."""
+    if len(data) < 6:
+        return f"SHORT ({len(data)} bytes): {_hex(data)}"
+    hdr, cmd, p1, p2, p3, ck = data[:6]
+    expected_ck = (cmd + p1 + p2 + p3) & 0xFF
+    ck_ok = "OK" if ck == expected_ck else f"BAD (expected {expected_ck:02x})"
+    return (
+        f"[{hdr:02x}] cmd={cmd:02x} p1={p1:02x} p2={p2:02x} p3={p3:02x} "
+        f"ck={ck:02x}({ck_ok})"
+    )
+
+
+# -- volume encoding per official doc: volume * 100, 24-bit big-endian ----
+
+
+def _vol_b2(vol_ul: int) -> tuple[int, int, int]:
+    """Encode volume for B2 (PI_VOLUM): volume * 100 across 3 bytes."""
+    v = vol_ul * 100
+    return ((v >> 16) & 0xFF, (v >> 8) & 0xFF, v & 0xFF)
+
+
+# -- test harness ----------------------------------------------------------
+
+
+class RemoteModeTest:
+    def __init__(self, port: str, timeout: float = 2.0):
+        import serial
+
+        self.port_name = port
+        self.ser = serial.Serial(
+            port=port,
+            baudrate=9600,
+            bytesize=8,
+            parity="N",
+            stopbits=1,
+            timeout=timeout,
+        )
+        self.log = logging.getLogger("EXP-049")
+
+    def close(self):
+        if self.ser and self.ser.is_open:
+            self.ser.close()
+
+    def send(
+        self, label: str, pkt: bytes, read_bytes: int = 6, pause: float = 0.5
+    ) -> bytes:
+        """Send a packet, read response, log everything."""
+        self.log.info("--- %s ---", label)
+        self.log.info("  TX: %s", _hex(pkt))
+        self.ser.reset_input_buffer()
+        self.ser.write(pkt)
+        self.ser.flush()
+        time.sleep(pause)
+        resp = self.ser.read(read_bytes)
+        if resp:
+            # Log each 6-byte frame separately
+            for i in range(0, len(resp), 6):
+                chunk = resp[i : i + 6]
+                self.log.info("  RX[%d]: %s  %s", i // 6, _hex(chunk), _desc_rx(chunk))
+        else:
+            self.log.info("  RX: (no response)")
+        return resp
+
+    def drain(self):
+        """Read and discard any pending bytes."""
+        leftover = self.ser.read(256)
+        if leftover:
+            self.log.info(
+                "  (drained %d leftover bytes: %s)", len(leftover), _hex(leftover)
+            )
+
+    def run(self, test_volume_ul: int = 200):
+        self.log.info("=" * 60)
+        self.log.info("EXP-049: Official DLAB remote control protocol test")
+        self.log.info("Port: %s  |  Test volume: %d uL", self.port_name, test_volume_ul)
+        self.log.info("=" * 60)
+
+        # ---- Phase 1: Official handshake (A0) ----
+        self.log.info("")
+        self.log.info("==== PHASE 1: Handshake ====")
+
+        r = self.send("A0 HELLO (official handshake)", _pkt(0xA0))
+        a0_works = len(r) >= 6 and r[0] == HEADER_RX
+
+        r = self.send("A5 b2=0 (our current 'handshake')", _pkt(0xA5, 0x00))
+        a5_works = len(r) >= 6 and r[0] == HEADER_RX
+
+        self.log.info("")
+        self.log.info("A0 responds: %s  |  A5 responds: %s", a0_works, a5_works)
+
+        # ---- Phase 2: Enter PI remote mode (B0 param=1) ----
+        self.log.info("")
+        self.log.info("==== PHASE 2: Enter PI mode (B0 param=1) ====")
+        self.log.info("Official doc says this enters pipetting mode + motor homes.")
+        self.log.info("We previously interpreted this as 'dispense'.")
+
+        r = self.send("B0 param=1 (enter PI mode)", _pkt(0xB0, 0x01), pause=2.0)
+        b0_success = len(r) >= 6 and r[0] == HEADER_RX and r[2] == 0x00
+        self.log.info("B0 accepted (p1=0): %s", b0_success)
+        self.drain()
+
+        # ---- Phase 3: Set speed (B1) ----
+        self.log.info("")
+        self.log.info("==== PHASE 3: Set speed (B1) ====")
+
+        r = self.send("B1 aspirate speed=2", _pkt(0xB1, 0x01, 0x02))
+        b1_suck = len(r) >= 6 and r[0] == HEADER_RX and r[2] == 0x00
+
+        r = self.send("B1 dispense speed=2", _pkt(0xB1, 0x02, 0x02))
+        b1_blow = len(r) >= 6 and r[0] == HEADER_RX and r[2] == 0x00
+
+        self.log.info(
+            "B1 suck speed accepted: %s  |  B1 blow speed accepted: %s",
+            b1_suck,
+            b1_blow,
+        )
+
+        # ---- Phase 4: Set volume via B2 (PI_VOLUM) ----
+        self.log.info("")
+        self.log.info("==== PHASE 4: Set volume via B2 (PI_VOLUM) ====")
+        hi, mid, lo = _vol_b2(test_volume_ul)
+        self.log.info(
+            "Volume %d uL -> %d (x100) -> bytes: %02x %02x %02x",
+            test_volume_ul,
+            test_volume_ul * 100,
+            hi,
+            mid,
+            lo,
+        )
+
+        r = self.send(
+            f"B2 PI_VOLUM = {test_volume_ul} uL",
+            _pkt(0xB2, hi, mid, lo),
+        )
+        b2_success = len(r) >= 6 and r[0] == HEADER_RX and r[2] == 0x00
+        self.log.info("B2 accepted (p1=0): %s", b2_success)
+
+        # ---- Phase 5: Aspirate via B3 b2=1 ----
+        self.log.info("")
+        self.log.info("==== PHASE 5: Aspirate (B3 param=1) ====")
+        self.log.info("Official doc says two responses: ACK then completion.")
+
+        input(">>> Tip attached and ready? Press Enter to aspirate...")
+
+        r = self.send(
+            "B3 param=1 (ASPIRATE)", _pkt(0xB3, 0x01), read_bytes=12, pause=5.0
+        )
+        b3_suck_len = len(r)
+        self.log.info("B3 aspirate response length: %d bytes", b3_suck_len)
+        self.drain()
+
+        # ---- Phase 6: Dispense via B3 b2=2 ----
+        self.log.info("")
+        self.log.info("==== PHASE 6: Dispense (B3 param=2) ====")
+        self.log.info("Official doc: b2=2 for blow. We've NEVER tested this.")
+
+        input(">>> Press Enter to dispense...")
+
+        r = self.send(
+            "B3 param=2 (DISPENSE)", _pkt(0xB3, 0x02), read_bytes=12, pause=5.0
+        )
+        b3_blow_len = len(r)
+        self.log.info("B3 dispense response length: %d bytes", b3_blow_len)
+        self.drain()
+
+        # ---- Phase 7: Fallback — test B2 + our known-working flow ----
+        self.log.info("")
+        self.log.info("==== PHASE 7: B2 volume + our known flow (B0 prime -> B3) ====")
+        self.log.info("If phases 5-6 failed, test whether B2 affects the known flow.")
+
+        # Re-send B2 volume
+        self.send(
+            f"B2 PI_VOLUM = {test_volume_ul} uL (re-send)", _pkt(0xB2, hi, mid, lo)
+        )
+
+        # Prime with B0 (our known working method)
+        self.send("B0 b2=1 (prime/home)", _pkt(0xB0, 0x01), pause=2.0)
+        self.drain()
+
+        input(">>> Press Enter to aspirate via B3 (after B2 + B0 prime)...")
+        r = self.send(
+            "B3 param=1 (aspirate after B2+B0)",
+            _pkt(0xB3, 0x01),
+            read_bytes=12,
+            pause=5.0,
+        )
+        self.drain()
+
+        # ---- Summary ----
+        self.log.info("")
+        self.log.info("=" * 60)
+        self.log.info("SUMMARY")
+        self.log.info("=" * 60)
+        self.log.info("A0 handshake responds:   %s", a0_works)
+        self.log.info("B0 PI mode accepted:     %s", b0_success)
+        self.log.info("B1 speed accepted:       suck=%s  blow=%s", b1_suck, b1_blow)
+        self.log.info("B2 volume accepted:      %s", b2_success)
+        self.log.info(
+            "B3 aspirate bytes:       %d  (expect 12 if motor moved)", b3_suck_len
+        )
+        self.log.info(
+            "B3 dispense bytes:       %d  (expect 12 if motor moved)", b3_blow_len
+        )
+        self.log.info("")
+        self.log.info("If B3 gave 12 bytes in phase 5, the official remote")
+        self.log.info("protocol works. Measure the liquid to check if B2")
+        self.log.info("volume was respected vs the dial volume.")
+        self.log.info("=" * 60)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="EXP-049: Test DLAB remote control protocol"
+    )
+    parser.add_argument(
+        "--port", default=None, help="Serial port (auto-detected if omitted)"
+    )
+    parser.add_argument(
+        "--volume", type=int, default=200, help="Test volume in uL (default: 200)"
+    )
+    args = parser.parse_args()
+
+    # Setup logging: console + file
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s [%(levelname)-8s] %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+        handlers=[
+            logging.StreamHandler(sys.stderr),
+            logging.FileHandler("captures/exp049_remote_mode.log", mode="w"),
+        ],
+    )
+
+    port = args.port
+    if port is None:
+        from dpette.config import guess_default_port
+
+        port = guess_default_port()
+    if port is None:
+        print("ERROR: No serial port found. Use --port to specify.", file=sys.stderr)
+        sys.exit(1)
+
+    t = RemoteModeTest(port)
+    try:
+        t.run(test_volume_ul=args.volume)
+    except KeyboardInterrupt:
+        print("\nAborted.")
+    finally:
+        t.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "A", "SIM", "TCH"]
 
 [tool.ruff.lint.per-file-ignores]
 "tools/*" = ["E501", "B007", "SIM115"]
+"examples/*" = ["E501"]
 
 [tool.mypy]
 python_version = "3.11"
@@ -59,6 +60,30 @@ mypy_path = "src"
 
 [[tool.mypy.overrides]]
 module = "tools.*"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "test_remote_mode"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "test_b2_volume"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "test_mix"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "test_driver_modes"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "test_driver_modes_2"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "test_dilution"
 ignore_errors = true
 
 [tool.pytest.ini_options]

--- a/src/dpette/__init__.py
+++ b/src/dpette/__init__.py
@@ -1,3 +1,7 @@
 """dpette — reverse-engineered driver for DLAB dPette electronic pipettes."""
 
-__version__ = "0.1.0"
+from dpette.config import SerialConfig, guess_default_port
+from dpette.driver import DPetteDriver
+
+__all__ = ["DPetteDriver", "SerialConfig", "guess_default_port"]
+__version__ = "0.2.0a1"

--- a/src/dpette/__init__.py
+++ b/src/dpette/__init__.py
@@ -2,6 +2,13 @@
 
 from dpette.config import SerialConfig, guess_default_port
 from dpette.driver import DPetteDriver
+from dpette.protocol import KeyAction, WorkingMode
 
-__all__ = ["DPetteDriver", "SerialConfig", "guess_default_port"]
+__all__ = [
+    "DPetteDriver",
+    "KeyAction",
+    "SerialConfig",
+    "WorkingMode",
+    "guess_default_port",
+]
 __version__ = "0.2.0a1"

--- a/src/dpette/config.py
+++ b/src/dpette/config.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 
 # Confirmed via live hardware probing (2026-04-06).
 DEFAULT_BAUDRATE: int = 9600
-DEFAULT_READ_TIMEOUT: float = 1.0
+DEFAULT_READ_TIMEOUT: float = 10.0
 
 CP210X_VID: int = 0x10C4
 CP210X_PID: int = 0xEA60

--- a/src/dpette/driver.py
+++ b/src/dpette/driver.py
@@ -1,8 +1,20 @@
 """High-level driver for DLAB dPette electronic pipettes.
 
-This module provides the user-facing API for controlling a pipette.
-Every method that can move the piston validates parameters through
-:mod:`dpette.safety` before issuing any serial commands.
+Implements the PipetteProtocol interface (connect, disconnect, aspirate,
+dispense, eject_tip) for integration with so101-biolab-automation and
+PyLabRobot.
+
+If the serial connection fails, the driver degrades gracefully to stub
+mode — all methods log warnings but don't raise, allowing CI/simulation
+to run without hardware.
+
+Volume control limitations:
+    - ``aspirate(volume_ul)`` accepts a volume parameter but the actual
+      aspirated volume is determined by the physical dial setting.
+    - For true volume control, use calibration mode: ``set_volume()``
+      sets the display via A6, then ``trigger_button()`` (GPIO/MOSFET)
+      triggers aspiration at that volume.
+    - See ``docs/PROTOCOL_NOTES.md`` for the full protocol spec.
 """
 
 from __future__ import annotations
@@ -18,6 +30,7 @@ from dpette.protocol import (
     dispense_packet,
     encode_packet,
     handshake_packet,
+    read_ee_packet,
     send_cali_volume_packet,
     write_ee_packet,
 )
@@ -42,7 +55,16 @@ READ_TIMEOUT_S: float = 1.0
 
 
 class DPetteDriver:
-    """Control interface for a single dPette or dPette+ pipette."""
+    """Control interface for a single dPette or dPette+ pipette.
+
+    Satisfies the ``PipetteProtocol`` structural protocol from
+    so101-biolab-automation (connect, disconnect, aspirate, dispense,
+    eject_tip).
+
+    If the serial connection fails during ``connect()``, the driver
+    enters **stub mode** — all commands are logged but no serial I/O
+    occurs.  This allows tests and simulations to run without hardware.
+    """
 
     def __init__(
         self,
@@ -54,24 +76,27 @@ class DPetteDriver:
         self._link = SerialLink(cfg)
         self._cycle_count: int = 0
         self._connected: bool = False
+        self._stub_mode: bool = False
+
+    @property
+    def stub_mode(self) -> bool:
+        """True if the driver is operating without hardware."""
+        return self._stub_mode
 
     # -- lifecycle ------------------------------------------------------------
 
     def connect(self) -> None:
         """Open the serial link, handshake, and prime the device.
 
-        After the handshake, sends a B0 "prime" command which is
-        required before the first B3 aspirate will be accepted.
+        If the connection fails, enters stub mode instead of raising.
 
         .. note::
            If the pipette shows Err4 on startup, dismiss it with the
            physical button **before** calling this method.
-
-        Raises ``RuntimeError`` if the handshake fails.
         """
         log.info("Connecting to dPette on %s", self._cfg.port)
-        self._link.open()
         try:
+            self._link.open()
             resp = self._transact(handshake_packet(), timeout=HANDSHAKE_TIMEOUT_S)
             if resp.cmd != Command.HANDSHAKE:
                 raise RuntimeError(
@@ -82,14 +107,16 @@ class DPetteDriver:
             log.info("Prime complete — device ready for aspirate/dispense")
             self._connected = True
             self._cycle_count = 0
-        except Exception:
-            self._link.close()
-            raise
+        except Exception as exc:
+            log.warning("dPette connection failed (%s) — entering stub mode", exc)
+            self._stub_mode = True
+            self._connected = True  # stub is "connected" for protocol purposes
 
     def disconnect(self) -> None:
         """Close the serial link."""
         log.info("Disconnecting from dPette")
-        self._link.close()
+        if not self._stub_mode:
+            self._link.close()
         self._connected = False
 
     def _require_connected(self) -> None:
@@ -99,10 +126,7 @@ class DPetteDriver:
     # -- protocol I/O ---------------------------------------------------------
 
     def _transact(self, pkt: bytes, timeout: float = READ_TIMEOUT_S) -> Packet:
-        """Send *pkt* and return the decoded 6-byte response.
-
-        The link's read timeout is temporarily adjusted to *timeout*.
-        """
+        """Send *pkt* and return the decoded 6-byte response."""
         self._link.write(pkt)
         raw = self._link.read(PACKET_LEN)
         if len(raw) < PACKET_LEN:
@@ -117,96 +141,143 @@ class DPetteDriver:
         self._require_connected()
         return self._transact(encode_packet(cmd, b2, b3, b4))
 
-    # -- commands -------------------------------------------------------------
+    # -- PipetteProtocol interface --------------------------------------------
 
-    def handshake(self, param: int = 0) -> Packet:
-        """Send a handshake / start-calibrate packet and return the response."""
-        self._require_connected()
-        return self._transact(handshake_packet(param))
-
-    def send_cali_volume(self, volume_ul: int) -> Packet:
-        """Tell the device which calibration volume to target (in µL)."""
-        self._require_connected()
-        return self._transact(send_cali_volume_packet(volume_ul))
-
-    def write_ee(self, addr: int, value: int = 0) -> Packet:
-        """Write a byte to an EEPROM address.
-
-        .. warning::
-           Address/value byte layout is provisional.  Use with caution.
-        """
-        self._require_connected()
-        return self._transact(write_ee_packet(addr, value))
-
-    def read_ee_raw(self, cmd: int, addr: int) -> Packet:
-        """Send a raw read-style command and return the response.
-
-        This is a low-level escape hatch for probing the protocol.
-        """
-        self._require_connected()
-        return self._transact(encode_packet(cmd, b2=addr & 0xFF))
-
-    # -- high-level API (stubs until read protocol is confirmed) ---------------
-
-    def identify(self) -> dict[str, str]:
-        """Query the pipette for its model name, firmware version, etc.
-
-        Not yet implemented — requires device type negotiation protocol.
-        """
-        self._require_connected()
-        raise NotImplementedError(
-            "Device identification requires a confirmed read protocol. "
-            "Use handshake() to verify connectivity."
-        )
-
-    def set_volume(self, microliters: float) -> None:
-        """Set the target aspiration / dispense volume."""
-        self._require_connected()
-        validate_volume(microliters, self._limits)
-        raise NotImplementedError(
-            "Volume setting requires confirmed motor control commands."
-        )
-
-    def aspirate(self) -> Packet:
+    def aspirate(self, volume_ul: float = 0.0) -> Packet | None:
         """Command the pipette to aspirate (draw liquid).
 
-        Aspirates at the pipette's current display volume.  The device
-        returns a double response: motor-started then motor-finished.
-        This method reads both and returns the final (completed) packet.
+        Parameters
+        ----------
+        volume_ul:
+            Requested volume in microlitres.  **Currently ignored** —
+            the actual volume is determined by the physical dial setting.
+            For volume control, use :meth:`set_volume` + :meth:`trigger_button`
+            in calibration mode.
+
+        Returns the final (completed) packet, or None in stub mode.
         """
         self._require_connected()
+        if self._stub_mode:
+            log.info("[STUB] aspirate(%.1f µL)", volume_ul)
+            return None
         self._check_cycle_limit()
         self._cycle_count += 1
-        log.info("Aspirating (cycle %d)", self._cycle_count)
+        if volume_ul > 0:
+            validate_volume(volume_ul, self._limits)
+        log.info("Aspirating %.1f µL (cycle %d)", volume_ul, self._cycle_count)
         self._link.write(aspirate_packet())
         # Aspirate returns 12 bytes: started (6) + completed (6)
         raw = self._link.read(PACKET_LEN * 2)
         if len(raw) < PACKET_LEN:
             raise TimeoutError("No response to aspirate command")
-        # Return the last 6-byte packet (completed)
         final = raw[-PACKET_LEN:]
         return decode_packet(final)
 
-    def dispense(self) -> Packet:
+    def dispense(self, volume_ul: float = 0.0) -> Packet | None:
         """Command the pipette to dispense (expel liquid).
 
-        Dispenses at the pipette's current display volume.
+        Parameters
+        ----------
+        volume_ul:
+            Requested volume.  **Currently ignored** — dispenses the
+            full aspirated amount.
+
+        Returns the response packet, or None in stub mode.
         """
         self._require_connected()
+        if self._stub_mode:
+            log.info("[STUB] dispense(%.1f µL)", volume_ul)
+            return None
         self._check_cycle_limit()
         self._cycle_count += 1
-        log.info("Dispensing (cycle %d)", self._cycle_count)
+        log.info("Dispensing %.1f µL (cycle %d)", volume_ul, self._cycle_count)
         return self._transact(dispense_packet())
 
-    def blow_out(self) -> None:
-        """Perform a blow-out to expel residual liquid from the tip."""
-        self._require_connected()
-        raise NotImplementedError("Blow-out command not yet reverse-engineered.")
-
     def eject_tip(self) -> None:
-        """Eject the currently attached pipette tip."""
+        """Eject the currently attached pipette tip.
+
+        Requires a GPIO-controlled actuator (BSS138 MOSFET or
+        optocoupler) wired across the pipette's tip eject button.
+        See GitHub issue #3 for wiring guide.
+
+        Currently raises NotImplementedError — will be implemented
+        when the MOSFET button hardware is wired.
+        """
         self._require_connected()
-        raise NotImplementedError("Tip ejection command not yet reverse-engineered.")
+        if self._stub_mode:
+            log.info("[STUB] eject_tip()")
+            return
+        raise NotImplementedError(
+            "Tip ejection requires GPIO button actuator (BSS138 MOSFET). "
+            "See https://github.com/Lambda-Biolab/dpette-usb-driver/issues/3"
+        )
+
+    # -- volume control (calibration mode) ------------------------------------
+
+    def set_volume(self, volume_ul: float) -> Packet | None:
+        """Set the target volume via A6 command.
+
+        Only takes effect in calibration mode — the motor will aspirate
+        at this volume when the physical button is pressed (or when
+        ``trigger_button()`` fires the MOSFET).
+
+        In normal mode, this command has no effect on motor travel.
+        """
+        self._require_connected()
+        if self._stub_mode:
+            log.info("[STUB] set_volume(%.1f µL)", volume_ul)
+            return None
+        validate_volume(volume_ul, self._limits)
+        log.info("Setting calibration volume to %.1f µL", volume_ul)
+        return self._transact(send_cali_volume_packet(int(volume_ul)))
+
+    def trigger_button(self) -> None:
+        """Electronically press the pipette's physical button.
+
+        Requires a GPIO-controlled actuator (BSS138 MOSFET) wired
+        across the button contacts, driven by an RP2040/Arduino GPIO.
+
+        Currently raises NotImplementedError — will be implemented
+        when the MOSFET button hardware is wired.
+        """
+        self._require_connected()
+        if self._stub_mode:
+            log.info("[STUB] trigger_button()")
+            return
+        raise NotImplementedError(
+            "Button trigger requires GPIO actuator (BSS138 MOSFET). "
+            "See https://github.com/Lambda-Biolab/dpette-usb-driver/issues/3"
+        )
+
+    # -- low-level commands ---------------------------------------------------
+
+    def handshake(self, param: int = 0) -> Packet | None:
+        """Send a handshake packet and return the response."""
+        self._require_connected()
+        if self._stub_mode:
+            return None
+        return self._transact(handshake_packet(param))
+
+    def send_cali_volume(self, volume_ul: int) -> Packet | None:
+        """Tell the device which calibration volume to target (in µL)."""
+        self._require_connected()
+        if self._stub_mode:
+            return None
+        return self._transact(send_cali_volume_packet(volume_ul))
+
+    def write_ee(self, addr: int, value: int = 0) -> Packet | None:
+        """Write a byte to an EEPROM address."""
+        self._require_connected()
+        if self._stub_mode:
+            return None
+        return self._transact(write_ee_packet(addr, value))
+
+    def read_ee(self, addr: int) -> Packet | None:
+        """Read a byte from an EEPROM address."""
+        self._require_connected()
+        if self._stub_mode:
+            return None
+        return self._transact(read_ee_packet(addr))
 
     # -- helpers --------------------------------------------------------------
 

--- a/src/dpette/driver.py
+++ b/src/dpette/driver.py
@@ -1,20 +1,18 @@
 """High-level driver for DLAB dPette electronic pipettes.
 
-Implements the PipetteProtocol interface (connect, disconnect, aspirate,
-dispense, eject_tip) for integration with so101-biolab-automation and
-PyLabRobot.
+Uses the official DLAB remote control protocol (confirmed EXP-049/050):
+
+    A0 (hello) -> B0 (enter mode) -> B2/B4-B7 (set params) -> B3 (suck/blow)
+
+Supports three operating modes:
+
+- **PI** (Pipetting): aspirate and dispense at a set volume.
+- **ST** (Splitting): aspirate once, dispense the same aliquot N times.
+- **DI** (Dilution): aspirate/dispense with two different volumes.
 
 If the serial connection fails, the driver degrades gracefully to stub
-mode — all methods log warnings but don't raise, allowing CI/simulation
+mode -- all methods log warnings but don't raise, allowing CI/simulation
 to run without hardware.
-
-Volume control limitations:
-    - ``aspirate(volume_ul)`` accepts a volume parameter but the actual
-      aspirated volume is determined by the physical dial setting.
-    - For true volume control, use calibration mode: ``set_volume()``
-      sets the display via A6, then ``trigger_button()`` (GPIO/MOSFET)
-      triggers aspiration at that volume.
-    - See ``docs/PROTOCOL_NOTES.md`` for the full protocol spec.
 """
 
 from __future__ import annotations
@@ -25,16 +23,24 @@ from dpette.logging_utils import get_logger
 from dpette.protocol import (
     PACKET_LEN,
     Command,
-    aspirate_packet,
+    KeyAction,
+    WorkingMode,
     decode_packet,
-    dispense_packet,
-    encode_packet,
-    handshake_packet,
+    demarcate_packet,
+    di1_volume_packet,
+    di2_volume_packet,
+    hello_packet,
+    key_packet,
+    pi_volume_packet,
     read_ee_packet,
     send_cali_volume_packet,
+    speed_packet,
+    st_num_packet,
+    st_volume_packet,
+    wol_packet,
     write_ee_packet,
 )
-from dpette.safety import DEFAULT_LIMITS, SafetyLimits, validate_volume
+from dpette.safety import DEFAULT_LIMITS, SafetyLimits, validate_speed, validate_volume
 from dpette.serial_link import SerialLink
 
 if TYPE_CHECKING:
@@ -48,21 +54,19 @@ MAX_CONTIGUOUS_CYCLES: int = 50
 cycles without an explicit reset.  Prevents mechanical abuse."""
 
 HANDSHAKE_TIMEOUT_S: float = 2.0
-"""Maximum seconds to wait for a handshake response."""
-
 READ_TIMEOUT_S: float = 1.0
-"""Maximum seconds to wait for a read response."""
+KEY_TIMEOUT_S: float = 10.0
+"""B3 (KEY) commands return 12 bytes; motor travel can take seconds."""
 
 
 class DPetteDriver:
     """Control interface for a single dPette or dPette+ pipette.
 
-    Satisfies the ``PipetteProtocol`` structural protocol from
-    so101-biolab-automation (connect, disconnect, aspirate, dispense,
-    eject_tip).
+    Supports PI (pipetting), ST (splitting), and DI (dilution) modes
+    via the official DLAB remote control protocol.
 
     If the serial connection fails during ``connect()``, the driver
-    enters **stub mode** — all commands are logged but no serial I/O
+    enters **stub mode** -- all commands are logged but no serial I/O
     occurs.  This allows tests and simulations to run without hardware.
     """
 
@@ -77,40 +81,44 @@ class DPetteDriver:
         self._cycle_count: int = 0
         self._connected: bool = False
         self._stub_mode: bool = False
+        self._mode: WorkingMode | None = None
 
     @property
     def stub_mode(self) -> bool:
         """True if the driver is operating without hardware."""
         return self._stub_mode
 
+    @property
+    def mode(self) -> WorkingMode | None:
+        """Current operating mode, or None if not yet set."""
+        return self._mode
+
     # -- lifecycle ------------------------------------------------------------
 
     def connect(self) -> None:
-        """Open the serial link, handshake, and prime the device.
+        """Open the serial link and handshake with the device.
 
-        If the connection fails, enters stub mode instead of raising.
-
-        .. note::
-           If the pipette shows Err4 on startup, dismiss it with the
-           physical button **before** calling this method.
+        Sends A0 (HELLO). Does NOT auto-enter a working mode -- call
+        :meth:`enter_mode` or let :meth:`aspirate`/:meth:`dispense`
+        lazily enter PI mode.
         """
         log.info("Connecting to dPette on %s", self._cfg.port)
         try:
             self._link.open()
-            resp = self._transact(handshake_packet(), timeout=HANDSHAKE_TIMEOUT_S)
-            if resp.cmd != Command.HANDSHAKE:
+            resp = self._transact(hello_packet(), timeout=HANDSHAKE_TIMEOUT_S)
+            if resp.cmd != Command.HELLO:
                 raise RuntimeError(
                     f"Unexpected handshake response cmd 0x{resp.cmd:02X}"
                 )
-            log.info("Handshake OK — sending B0 prime")
-            self._transact(dispense_packet())
-            log.info("Prime complete — device ready for aspirate/dispense")
+            log.info("Handshake OK (A0)")
             self._connected = True
             self._cycle_count = 0
+            # Enter PI mode now so the motor homes before a tip touches liquid
+            self.enter_mode(WorkingMode.PI)
         except Exception as exc:
-            log.warning("dPette connection failed (%s) — entering stub mode", exc)
+            log.warning("dPette connection failed (%s) -- entering stub mode", exc)
             self._stub_mode = True
-            self._connected = True  # stub is "connected" for protocol purposes
+            self._connected = True
 
     def disconnect(self) -> None:
         """Close the serial link."""
@@ -118,15 +126,20 @@ class DPetteDriver:
         if not self._stub_mode:
             self._link.close()
         self._connected = False
+        self._mode = None
 
     def _require_connected(self) -> None:
         if not self._connected:
-            raise RuntimeError("Not connected — call connect() first")
+            raise RuntimeError("Not connected -- call connect() first")
 
     # -- protocol I/O ---------------------------------------------------------
 
     def _transact(self, pkt: bytes, timeout: float = READ_TIMEOUT_S) -> Packet:
-        """Send *pkt* and return the decoded 6-byte response."""
+        """Send *pkt* and return the decoded 6-byte response.
+
+        Flushes any stale bytes in the receive buffer before sending.
+        """
+        self._link.flush_input()
         self._link.write(pkt)
         raw = self._link.read(PACKET_LEN)
         if len(raw) < PACKET_LEN:
@@ -136,72 +149,267 @@ class DPetteDriver:
             )
         return decode_packet(raw)
 
-    def _send_command(self, cmd: int, b2: int = 0, b3: int = 0, b4: int = 0) -> Packet:
-        """Encode, send, and return the response for a single command."""
-        self._require_connected()
-        return self._transact(encode_packet(cmd, b2, b3, b4))
+    def _key_command(self, action: KeyAction) -> Packet:
+        """Send B3 (KEY) and read the double 6-byte response.
 
-    # -- PipetteProtocol interface --------------------------------------------
+        The device sends an ACK (b2=0x00) immediately, then a completion
+        packet after the motor finishes.  We read them separately so the
+        motor has time to complete.  Stale packets from prior commands
+        are discarded before sending.
+
+        Returns the second (completion) packet.
+        """
+        self._link.flush_input()
+        # Brief pause to let any late-arriving stale bytes settle
+        import time
+
+        time.sleep(0.1)
+        self._link.flush_input()
+        self._link.write(key_packet(action))
+        # Read ACK (arrives quickly)
+        ack = self._link.read(PACKET_LEN)
+        if len(ack) < PACKET_LEN:
+            raise TimeoutError("No ACK response to KEY command")
+        # Read completion (may take seconds while motor moves)
+        done = self._link.read(PACKET_LEN)
+        if len(done) < PACKET_LEN:
+            log.warning("KEY command: got ACK but no completion (motor timeout?)")
+            return decode_packet(ack)
+        return decode_packet(done)
+
+    # -- mode management ------------------------------------------------------
+
+    def enter_mode(self, mode: WorkingMode) -> Packet | None:
+        """Enter a working mode via B0 (WOL).
+
+        Triggers motor homing. Must be called before aspirate/dispense
+        or mode-specific volume commands.
+        """
+        self._require_connected()
+        if self._stub_mode:
+            log.info("[STUB] enter_mode(%s)", mode.name)
+            self._mode = mode
+            return None
+        log.info("Entering %s mode (B0 param=%d)", mode.name, mode.value)
+        resp = self._transact(wol_packet(mode))
+        self._mode = mode
+        return resp
+
+    def _ensure_pi_mode(self) -> None:
+        """Lazily enter PI mode if no mode is set."""
+        if self._mode is None:
+            self.enter_mode(WorkingMode.PI)
+
+    # -- speed control --------------------------------------------------------
+
+    def set_speed(self, direction: KeyAction, speed: int) -> Packet | None:
+        """Set aspirate or dispense speed (B1).
+
+        Parameters
+        ----------
+        direction:
+            ``KeyAction.SUCK`` for aspirate speed, ``KeyAction.BLOW``
+            for dispense speed.
+        speed:
+            Speed level 1-3 (slow to fast).
+        """
+        self._require_connected()
+        if self._stub_mode:
+            log.info("[STUB] set_speed(%s, %d)", direction.name, speed)
+            return None
+        validate_speed(speed, self._limits)
+        log.info("Setting %s speed to %d", direction.name, speed)
+        return self._transact(speed_packet(direction, speed))
+
+    # -- PI mode (pipetting) --------------------------------------------------
 
     def aspirate(self, volume_ul: float = 0.0) -> Packet | None:
-        """Command the pipette to aspirate (draw liquid).
+        """Aspirate (draw liquid) via B3 suck.
 
-        Parameters
-        ----------
-        volume_ul:
-            Requested volume in microlitres.  **Currently ignored** —
-            the actual volume is determined by the physical dial setting.
-            For volume control, use :meth:`set_volume` + :meth:`trigger_button`
-            in calibration mode.
-
-        Returns the final (completed) packet, or None in stub mode.
+        If *volume_ul* > 0, sends B2 to set the volume first.
+        Auto-enters PI mode if no mode is set.
         """
         self._require_connected()
         if self._stub_mode:
-            log.info("[STUB] aspirate(%.1f µL)", volume_ul)
+            log.info("[STUB] aspirate(%.1f uL)", volume_ul)
             return None
         self._check_cycle_limit()
         self._cycle_count += 1
+        self._ensure_pi_mode()
         if volume_ul > 0:
             validate_volume(volume_ul, self._limits)
-        log.info("Aspirating %.1f µL (cycle %d)", volume_ul, self._cycle_count)
-        self._link.write(aspirate_packet())
-        # Aspirate returns 12 bytes: started (6) + completed (6)
-        raw = self._link.read(PACKET_LEN * 2)
-        if len(raw) < PACKET_LEN:
-            raise TimeoutError("No response to aspirate command")
-        final = raw[-PACKET_LEN:]
-        return decode_packet(final)
+            self.set_volume(volume_ul)
+        log.info("Aspirating (cycle %d)", self._cycle_count)
+        return self._key_command(KeyAction.SUCK)
 
     def dispense(self, volume_ul: float = 0.0) -> Packet | None:
-        """Command the pipette to dispense (expel liquid).
+        """Dispense (expel liquid) via B3 blow.
+
+        If *volume_ul* > 0, sends B2 to set the volume first.
+        Auto-enters PI mode if no mode is set.
+        """
+        self._require_connected()
+        if self._stub_mode:
+            log.info("[STUB] dispense(%.1f uL)", volume_ul)
+            return None
+        self._check_cycle_limit()
+        self._cycle_count += 1
+        self._ensure_pi_mode()
+        if volume_ul > 0:
+            validate_volume(volume_ul, self._limits)
+            self.set_volume(volume_ul)
+        log.info("Dispensing (cycle %d)", self._cycle_count)
+        return self._key_command(KeyAction.BLOW)
+
+    def set_volume(self, volume_ul: float) -> Packet | None:
+        """Set the pipetting volume via B2 (PI_VOLUM).
+
+        Controls actual motor travel in PI mode (confirmed EXP-050).
+        """
+        self._require_connected()
+        if self._stub_mode:
+            log.info("[STUB] set_volume(%.1f uL)", volume_ul)
+            return None
+        validate_volume(volume_ul, self._limits)
+        log.info("Setting PI volume to %.1f uL", volume_ul)
+        return self._transact(pi_volume_packet(volume_ul))
+
+    def mix_aspirate(self, volume_ul: float, speed: int = 3) -> Packet:
+        """Aspirate step of a mix cycle. Tip should be in liquid.
+
+        Call :meth:`mix_dispense` next, with tip raised above liquid.
+
+        On first call, sets speed and volume. Subsequent calls reuse
+        the same settings.
+        """
+        self._require_connected()
+        if self._stub_mode:
+            log.info("[STUB] mix_aspirate(%.1f uL)", volume_ul)
+            return None  # type: ignore[return-value]
+        self._ensure_pi_mode()
+        validate_volume(volume_ul, self._limits)
+        self.set_speed(KeyAction.SUCK, speed)
+        self.set_speed(KeyAction.BLOW, speed)
+        self.set_volume(volume_ul)
+        log.info("Mix aspirate %.1f uL", volume_ul)
+        return self._key_command(KeyAction.SUCK)
+
+    def mix_dispense(self) -> Packet:
+        """Dispense step of a mix cycle. Tip should be above liquid.
+
+        The blow includes a piston return to home, which creates
+        suction — if the tip is submerged, this draws extra liquid.
+        Always dispense in air or above the liquid surface.
+        """
+        self._require_connected()
+        if self._stub_mode:
+            log.info("[STUB] mix_dispense()")
+            return None  # type: ignore[return-value]
+        log.info("Mix dispense (blow in air)")
+        return self._key_command(KeyAction.BLOW)
+
+    # -- ST mode (splitting) --------------------------------------------------
+
+    def split_setup(self, volume_ul: float, count: int) -> None:
+        """Configure splitting: enter ST mode and set volume/count.
+
+        Call this with the tip in air — B0 homes the motor.
+        Then call :meth:`split_aspirate` with tip in liquid, and
+        :meth:`split_dispense` for each aliquot with tip above liquid.
 
         Parameters
         ----------
         volume_ul:
-            Requested volume.  **Currently ignored** — dispenses the
-            full aspirated amount.
-
-        Returns the response packet, or None in stub mode.
+            Volume per aliquot (must be <= max_volume / 2).
+        count:
+            Number of aliquots (volume * count must be <= max_volume).
         """
         self._require_connected()
         if self._stub_mode:
-            log.info("[STUB] dispense(%.1f µL)", volume_ul)
+            log.info("[STUB] split_setup(%.1f uL x %d)", volume_ul, count)
+            return
+        validate_volume(volume_ul, self._limits)
+        if self._mode != WorkingMode.ST:
+            self.enter_mode(WorkingMode.ST)
+        log.info("Split setup: %.1f uL x %d aliquots", volume_ul, count)
+        self._transact(st_volume_packet(volume_ul))
+        self._transact(st_num_packet(count))
+
+    def split_aspirate(self) -> Packet | None:
+        """Aspirate the total split volume. Tip should be in liquid."""
+        self._require_connected()
+        if self._stub_mode:
+            log.info("[STUB] split_aspirate()")
             return None
-        self._check_cycle_limit()
-        self._cycle_count += 1
-        log.info("Dispensing %.1f µL (cycle %d)", volume_ul, self._cycle_count)
-        return self._transact(dispense_packet())
+        log.info("Split aspirate")
+        return self._key_command(KeyAction.SUCK)
+
+    def split_dispense(self) -> Packet | None:
+        """Dispense one aliquot. Tip should be above liquid.
+
+        The blow includes a piston return — dispense in air or above
+        the liquid surface to avoid drawing extra liquid back in.
+        """
+        self._require_connected()
+        if self._stub_mode:
+            log.info("[STUB] split_dispense()")
+            return None
+        log.info("Split dispense")
+        return self._key_command(KeyAction.BLOW)
+
+    # -- DI mode (dilution) ---------------------------------------------------
+
+    def dilute_setup(self, volume1_ul: float, volume2_ul: float) -> None:
+        """Configure dilution: enter DI mode and set both volumes.
+
+        Call this with the tip in air — B0 homes the motor.
+        Then use :meth:`dilute_aspirate` (tip in liquid) and
+        :meth:`dilute_dispense` (tip above liquid) for each step.
+
+        Parameters
+        ----------
+        volume1_ul:
+            First aspiration volume.
+        volume2_ul:
+            Second aspiration volume.
+        """
+        self._require_connected()
+        if self._stub_mode:
+            log.info("[STUB] dilute_setup(%.1f, %.1f uL)", volume1_ul, volume2_ul)
+            return
+        validate_volume(volume1_ul, self._limits)
+        validate_volume(volume2_ul, self._limits)
+        if self._mode != WorkingMode.DI:
+            self.enter_mode(WorkingMode.DI)
+        log.info("Dilution setup: vol1=%.1f uL, vol2=%.1f uL", volume1_ul, volume2_ul)
+        self._transact(di1_volume_packet(volume1_ul))
+        self._transact(di2_volume_packet(volume2_ul))
+
+    def dilute_aspirate(self) -> Packet | None:
+        """Aspirate one dilution step. Tip should be in liquid."""
+        self._require_connected()
+        if self._stub_mode:
+            log.info("[STUB] dilute_aspirate()")
+            return None
+        log.info("Dilution aspirate")
+        return self._key_command(KeyAction.SUCK)
+
+    def dilute_dispense(self) -> Packet | None:
+        """Dispense one dilution step. Tip should be above liquid."""
+        self._require_connected()
+        if self._stub_mode:
+            log.info("[STUB] dilute_dispense()")
+            return None
+        log.info("Dilution dispense")
+        return self._key_command(KeyAction.BLOW)
+
+    # -- tip management -------------------------------------------------------
 
     def eject_tip(self) -> None:
         """Eject the currently attached pipette tip.
 
         Requires a GPIO-controlled actuator (BSS138 MOSFET or
         optocoupler) wired across the pipette's tip eject button.
-        See GitHub issue #3 for wiring guide.
-
-        Currently raises NotImplementedError — will be implemented
-        when the MOSFET button hardware is wired.
         """
         self._require_connected()
         if self._stub_mode:
@@ -212,68 +420,39 @@ class DPetteDriver:
             "See https://github.com/Lambda-Biolab/dpette-usb-driver/issues/3"
         )
 
-    # -- volume control (calibration mode) ------------------------------------
+    # -- calibration commands (A5/A6, separate from remote control) -----------
 
-    def set_volume(self, volume_ul: float) -> Packet | None:
-        """Set the target volume via A6 command.
+    def demarcate(self, param: int = 0) -> Packet | None:
+        """Enter or exit calibration mode (A5).
 
-        Only takes effect in calibration mode — the motor will aspirate
-        at this volume when the physical button is pressed (or when
-        ``trigger_button()`` fires the MOSFET).
+        ``param=0``: exit.  ``param=1``: enter.
 
-        In normal mode, this command has no effect on motor travel.
+        .. warning::
+           param=1 causes persistent Err4 on reboot.
         """
         self._require_connected()
         if self._stub_mode:
-            log.info("[STUB] set_volume(%.1f µL)", volume_ul)
             return None
-        validate_volume(volume_ul, self._limits)
-        log.info("Setting calibration volume to %.1f µL", volume_ul)
-        return self._transact(send_cali_volume_packet(int(volume_ul)))
+        return self._transact(demarcate_packet(param))
 
-    def trigger_button(self) -> None:
-        """Electronically press the pipette's physical button.
-
-        Requires a GPIO-controlled actuator (BSS138 MOSFET) wired
-        across the button contacts, driven by an RP2040/Arduino GPIO.
-
-        Currently raises NotImplementedError — will be implemented
-        when the MOSFET button hardware is wired.
-        """
-        self._require_connected()
-        if self._stub_mode:
-            log.info("[STUB] trigger_button()")
-            return
-        raise NotImplementedError(
-            "Button trigger requires GPIO actuator (BSS138 MOSFET). "
-            "See https://github.com/Lambda-Biolab/dpette-usb-driver/issues/3"
-        )
-
-    # -- low-level commands ---------------------------------------------------
-
-    def handshake(self, param: int = 0) -> Packet | None:
-        """Send a handshake packet and return the response."""
-        self._require_connected()
-        if self._stub_mode:
-            return None
-        return self._transact(handshake_packet(param))
-
-    def send_cali_volume(self, volume_ul: int) -> Packet | None:
-        """Tell the device which calibration volume to target (in µL)."""
+    def set_cali_volume(self, volume_ul: int) -> Packet | None:
+        """Set calibration display volume (A6). Does NOT control motor."""
         self._require_connected()
         if self._stub_mode:
             return None
         return self._transact(send_cali_volume_packet(volume_ul))
 
+    # -- low-level EEPROM commands --------------------------------------------
+
     def write_ee(self, addr: int, value: int = 0) -> Packet | None:
-        """Write a byte to an EEPROM address."""
+        """Write a byte to an EEPROM address (A4)."""
         self._require_connected()
         if self._stub_mode:
             return None
         return self._transact(write_ee_packet(addr, value))
 
     def read_ee(self, addr: int) -> Packet | None:
-        """Read a byte from an EEPROM address."""
+        """Read a byte from an EEPROM address (A3)."""
         self._require_connected()
         if self._stub_mode:
             return None
@@ -289,6 +468,6 @@ class DPetteDriver:
     def _check_cycle_limit(self) -> None:
         if self._cycle_count >= MAX_CONTIGUOUS_CYCLES:
             raise RuntimeError(
-                f"Reached {MAX_CONTIGUOUS_CYCLES} contiguous cycles — "
+                f"Reached {MAX_CONTIGUOUS_CYCLES} contiguous cycles -- "
                 "call reset_cycle_count() after inspecting the pipette."
             )

--- a/src/dpette/protocol.py
+++ b/src/dpette/protocol.py
@@ -4,12 +4,14 @@ All packets are 6 bytes::
 
     [HEADER] [CMD] [B2] [B3] [B4] [CHECKSUM]
 
-Header is ``0xFE`` for host→device, ``0xFD`` for device→host.
+Header is ``0xFE`` for host->device, ``0xFD`` for device->host.
 Checksum is ``sum(bytes[1:5]) & 0xFF``.
 
+Command names and semantics come from the official DLAB protocol document
+(Communication_Protocol_CN.doc, confirmed live in EXP-049/050).
+
 This module owns the byte-level framing but knows nothing about
-high-level commands like "aspirate" or "dispense".  Actual serial I/O
-lives in :mod:`dpette.serial_link`.
+high-level operations.  Actual serial I/O lives in :mod:`dpette.serial_link`.
 """
 
 from __future__ import annotations
@@ -18,24 +20,57 @@ import enum
 from dataclasses import dataclass
 
 HEADER_TX: int = 0xFE
-"""Header byte for host → device packets."""
+"""Header byte for host -> device packets."""
 
 HEADER_RX: int = 0xFD
-"""Header byte for device → host packets."""
+"""Header byte for device -> host packets."""
 
 PACKET_LEN: int = 6
 """Every packet (TX and RX) is exactly 6 bytes."""
 
 
 class Command(enum.IntEnum):
-    """Known command bytes (confirmed via disassembly + live probing)."""
+    """Known command bytes from the official DLAB protocol document.
 
-    HANDSHAKE = 0xA5
-    SEND_CALI_VOLUME = 0xA6
-    WRITE_EE = 0xA4
-    DATA = 0xA3
-    ASPIRATE = 0xB3
-    DISPENSE = 0xB0
+    Info commands (0xA0-0xA8) handle handshake, EEPROM, and calibration.
+    Control commands (0xB0-0xB7) handle remote pipetting, splitting, dilution.
+    """
+
+    # -- Info commands --
+    HELLO = 0xA0
+    INFO = 0xA1
+    STA = 0xA2
+    EE_READ = 0xA3
+    EE_WRITE = 0xA4
+    DEMARCATE = 0xA5
+    DMRCT_VOLUM = 0xA6
+    RESET = 0xA7
+    DMRCT_PULSE = 0xA8
+
+    # -- Control commands --
+    WOL = 0xB0
+    SPEED = 0xB1
+    PI_VOLUM = 0xB2
+    KEY = 0xB3
+    ST_VOLUM = 0xB4
+    ST_NUM = 0xB5
+    DI1_VOLUM = 0xB6
+    DI2_VOLUM = 0xB7
+
+
+class WorkingMode(enum.IntEnum):
+    """Operating modes for the B0 (WOL) command."""
+
+    PI = 1  # Pipetting
+    ST = 2  # Splitting
+    DI = 3  # Dilution
+
+
+class KeyAction(enum.IntEnum):
+    """Actions for the B3 (KEY) command."""
+
+    SUCK = 1  # Aspirate
+    BLOW = 2  # Dispense
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,8 +101,8 @@ def compute_checksum(cmd: int, b2: int, b3: int, b4: int) -> int:
 def encode_packet(cmd: int, b2: int = 0, b3: int = 0, b4: int = 0) -> bytes:
     """Build a 6-byte TX packet with computed checksum.
 
-    >>> encode_packet(Command.HANDSHAKE).hex(' ')
-    'fe a5 00 00 00 a5'
+    >>> encode_packet(Command.HELLO).hex(' ')
+    'fe a0 00 00 00 a0'
     """
     cksum = compute_checksum(cmd, b2, b3, b4)
     return bytes([HEADER_TX, cmd, b2, b3, b4, cksum])
@@ -95,73 +130,218 @@ def decode_packet(raw: bytes) -> Packet:
 
 
 # ---------------------------------------------------------------------------
-# High-level packet builders
+# Volume encoding helpers
 # ---------------------------------------------------------------------------
 
 
-def handshake_packet(param: int = 0) -> bytes:
-    """Build a HandShake / StartCalibrate packet.
+def _encode_volume_x100(volume_ul: float) -> tuple[int, int, int]:
+    """Encode volume as 24-bit big-endian (volume * 100).
 
-    ``param=0`` for connection check, ``param=1`` for start calibrate.
+    Used by B2 (PI_VOLUM), B4 (ST_VOLUM), B6 (DI1_VOLUM), B7 (DI2_VOLUM).
     """
-    return encode_packet(Command.HANDSHAKE, b2=param)
+    v = int(volume_ul * 100)
+    return ((v >> 16) & 0xFF, (v >> 8) & 0xFF, v & 0xFF)
 
 
-def send_cali_volume_packet(volume_ul: int) -> bytes:
-    """Build a SendCaliVolume packet.
+def _encode_volume_x10(volume_ul: int) -> tuple[int, int]:
+    """Encode volume as 16-bit big-endian (volume * 10).
 
-    Volume is encoded as ``volume_µL × 10``, big-endian in bytes[2:3].
-
-    >>> send_cali_volume_packet(1000).hex(' ')
-    'fe a6 27 10 00 dd'
+    Used by A6 (DMRCT_VOLUM) for calibration.
     """
-    val = volume_ul * 10
-    hi = (val >> 8) & 0xFF
-    lo = val & 0xFF
-    return encode_packet(Command.SEND_CALI_VOLUME, b2=hi, b3=lo)
+    v = volume_ul * 10
+    return ((v >> 8) & 0xFF, v & 0xFF)
+
+
+# ---------------------------------------------------------------------------
+# Packet builders — Info commands (A0-A8)
+# ---------------------------------------------------------------------------
+
+
+def hello_packet() -> bytes:
+    """Build a HELLO handshake packet (A0).
+
+    >>> hello_packet().hex(' ')
+    'fe a0 00 00 00 a0'
+    """
+    return encode_packet(Command.HELLO)
+
+
+def info_packet() -> bytes:
+    """Build an INFO packet (A1) — read device type and volume range."""
+    return encode_packet(Command.INFO)
+
+
+def status_packet() -> bytes:
+    """Build a STA packet (A2) — read device status."""
+    return encode_packet(Command.STA)
 
 
 def read_ee_packet(addr: int) -> bytes:
-    """Build a ReadEE packet.
+    """Build a ReadEE packet (A3).
 
     Address goes in byte[3] (confirmed from PetteCali serial capture).
 
     >>> read_ee_packet(0x90).hex(' ')
     'fe a3 00 90 00 33'
     """
-    return encode_packet(Command.DATA, b2=0x00, b3=addr & 0xFF)
+    return encode_packet(Command.EE_READ, b2=0x00, b3=addr & 0xFF)
 
 
 def write_ee_packet(addr: int, value: int = 0) -> bytes:
-    """Build a WriteEE packet.
+    """Build a WriteEE packet (A4).
 
-    Address in byte[3], value in byte[4] (confirmed from PetteCali
-    serial capture).
+    Address in byte[3], value in byte[4].
 
     >>> write_ee_packet(0x92, 0x2F).hex(' ')
     'fe a4 00 92 2f 65'
     """
-    return encode_packet(Command.WRITE_EE, b2=0x00, b3=addr & 0xFF, b4=value & 0xFF)
+    return encode_packet(Command.EE_WRITE, b2=0x00, b3=addr & 0xFF, b4=value & 0xFF)
 
 
-def aspirate_packet() -> bytes:
-    """Build an Aspirate packet.
+def demarcate_packet(param: int = 0) -> bytes:
+    """Build a DEMARCATE packet (A5) — enter/exit calibration mode.
 
-    Aspirates at the pipette's current display volume.
-    The device returns a double response (started + completed).
+    ``param=0``: exit calibration mode.
+    ``param=1``: enter calibration mode.
 
-    >>> aspirate_packet().hex(' ')
-    'fe b3 01 00 00 b4'
+    .. warning::
+       A5 param=1 causes persistent Err4 on reboot. Use with caution.
     """
-    return encode_packet(Command.ASPIRATE, b2=0x01)
+    return encode_packet(Command.DEMARCATE, b2=param)
 
 
-def dispense_packet() -> bytes:
-    """Build a Dispense packet.
+def send_cali_volume_packet(volume_ul: int) -> bytes:
+    """Build a SendCaliVolume packet (A6).
 
-    Dispenses at the pipette's current display volume.
+    Volume is encoded as ``volume_uL * 10``, big-endian in bytes[2:3].
+    Only affects display in calibration mode — does NOT control motor.
 
-    >>> dispense_packet().hex(' ')
+    >>> send_cali_volume_packet(1000).hex(' ')
+    'fe a6 27 10 00 dd'
+    """
+    hi, lo = _encode_volume_x10(volume_ul)
+    return encode_packet(Command.DMRCT_VOLUM, b2=hi, b3=lo)
+
+
+def reset_packet() -> bytes:
+    """Build a RESET packet (A7) — restore factory calibration values."""
+    return encode_packet(Command.RESET)
+
+
+def dmrct_pulse_packet(pulse_count: int) -> bytes:
+    """Build a DMRCT_PULSE packet (A8) — set calibration pulse count.
+
+    Pulse count is 16-bit big-endian in bytes[2:3].
+    """
+    hi = (pulse_count >> 8) & 0xFF
+    lo = pulse_count & 0xFF
+    return encode_packet(Command.DMRCT_PULSE, b2=hi, b3=lo)
+
+
+# ---------------------------------------------------------------------------
+# Packet builders — Control commands (B0-B7)
+# ---------------------------------------------------------------------------
+
+
+def wol_packet(mode: int) -> bytes:
+    """Build a WOL packet (B0) — enter a working mode.
+
+    Mode: 1=PI (pipetting), 2=ST (splitting), 3=DI (dilution).
+    Triggers motor homing on the device.
+
+    >>> wol_packet(WorkingMode.PI).hex(' ')
     'fe b0 01 00 00 b1'
     """
-    return encode_packet(Command.DISPENSE, b2=0x01)
+    return encode_packet(Command.WOL, b2=mode)
+
+
+def speed_packet(direction: int, speed: int) -> bytes:
+    """Build a SPEED packet (B1) — set aspirate or dispense speed.
+
+    Direction: 1=suck (aspirate), 2=blow (dispense).
+    Speed: 1-3 (slow to fast).
+
+    >>> speed_packet(1, 2).hex(' ')
+    'fe b1 01 02 00 b4'
+    """
+    return encode_packet(Command.SPEED, b2=direction, b3=speed)
+
+
+def pi_volume_packet(volume_ul: float) -> bytes:
+    """Build a PI_VOLUM packet (B2) — set pipetting volume.
+
+    Volume is encoded as ``volume_uL * 100``, 24-bit big-endian.
+    This controls actual motor travel in PI mode (confirmed EXP-050).
+
+    >>> pi_volume_packet(200.0).hex(' ')
+    'fe b2 00 4e 20 20'
+    """
+    hi, mid, lo = _encode_volume_x100(volume_ul)
+    return encode_packet(Command.PI_VOLUM, b2=hi, b3=mid, b4=lo)
+
+
+def key_packet(action: int) -> bytes:
+    """Build a KEY packet (B3) — aspirate or dispense.
+
+    Action: 1=suck (aspirate), 2=blow (dispense).
+    Returns double 6-byte response: ACK then completion.
+
+    >>> key_packet(KeyAction.SUCK).hex(' ')
+    'fe b3 01 00 00 b4'
+    >>> key_packet(KeyAction.BLOW).hex(' ')
+    'fe b3 02 00 00 b5'
+    """
+    return encode_packet(Command.KEY, b2=action)
+
+
+def st_volume_packet(volume_ul: float) -> bytes:
+    """Build a ST_VOLUM packet (B4) — set split volume per aliquot.
+
+    Volume * 100, 24-bit big-endian. Must be <= max_volume / 2.
+    """
+    hi, mid, lo = _encode_volume_x100(volume_ul)
+    return encode_packet(Command.ST_VOLUM, b2=hi, b3=mid, b4=lo)
+
+
+def st_num_packet(count: int) -> bytes:
+    """Build a ST_NUM packet (B5) — set number of splits.
+
+    Single byte count. Constraint: split_volume * count <= max_volume.
+    """
+    return encode_packet(Command.ST_NUM, b2=count)
+
+
+def di1_volume_packet(volume_ul: float) -> bytes:
+    """Build a DI1_VOLUM packet (B6) — set first dilution volume.
+
+    Volume * 100, 24-bit big-endian.
+    """
+    hi, mid, lo = _encode_volume_x100(volume_ul)
+    return encode_packet(Command.DI1_VOLUM, b2=hi, b3=mid, b4=lo)
+
+
+def di2_volume_packet(volume_ul: float) -> bytes:
+    """Build a DI2_VOLUM packet (B7) — set second dilution volume.
+
+    Volume * 100, 24-bit big-endian.
+    """
+    hi, mid, lo = _encode_volume_x100(volume_ul)
+    return encode_packet(Command.DI2_VOLUM, b2=hi, b3=mid, b4=lo)
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatible aliases (old names -> new names)
+# ---------------------------------------------------------------------------
+
+handshake_packet = demarcate_packet
+"""Deprecated alias — the old ``handshake_packet()`` actually sent A5
+(DEMARCATE), not A0 (HELLO).  Use :func:`hello_packet` for the real
+handshake and :func:`demarcate_packet` for calibration mode."""
+
+aspirate_packet = lambda: key_packet(KeyAction.SUCK)  # noqa: E731
+"""Deprecated alias — use ``key_packet(KeyAction.SUCK)``."""
+
+dispense_packet = lambda: wol_packet(WorkingMode.PI)  # noqa: E731
+"""Deprecated alias — the old ``dispense_packet()`` actually sent B0
+(enter PI mode), not B3 blow.  Use ``key_packet(KeyAction.BLOW)`` for
+actual dispense."""

--- a/src/dpette/safety.py
+++ b/src/dpette/safety.py
@@ -33,9 +33,9 @@ class SafetyLimits(NamedTuple):
 DEFAULT_LIMITS = SafetyLimits(
     max_volume_ul=1000.0,
     max_cycles=50,
-    max_speed_level=5,
+    max_speed_level=3,
 )
-"""Conservative defaults — tighten once real hardware limits are confirmed."""
+"""Conservative defaults — speed 1-3 per official DLAB protocol."""
 
 
 def validate_volume(volume_ul: float, limits: SafetyLimits) -> None:

--- a/src/dpette/serial_link.py
+++ b/src/dpette/serial_link.py
@@ -85,6 +85,14 @@ class SerialLink:
             raise RuntimeError("Serial port is not open")
         return self._port
 
+    def flush_input(self) -> None:
+        """Discard any bytes waiting in the receive buffer."""
+        port = self._require_open()
+        stale = port.in_waiting
+        if stale:
+            discarded = port.read(stale)
+            log.debug("FLUSH %d stale bytes: %s", len(discarded), discarded.hex(" "))
+
     def write(self, data: bytes) -> None:
         """Write *data* to the serial port.
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -21,6 +21,8 @@ from dpette.safety import SafetyError
 # Canned response bytes for mocking
 HANDSHAKE_RX = bytes.fromhex("fd a5 00 00 00 a5")
 CALI_VOL_RX = bytes.fromhex("fd a6 00 00 00 a6")
+ASPIRATE_RX_DOUBLE = bytes.fromhex("fd b3 00 00 00 b3 fd b3 01 00 00 b4")
+DISPENSE_RX = bytes.fromhex("fd b0 00 00 00 b0")
 
 
 @pytest.fixture()
@@ -48,20 +50,25 @@ def connected_driver(cfg: SerialConfig, mock_serial: MagicMock) -> DPetteDriver:
 
 
 class TestDriverRequiresConnection:
-    def test_identify_requires_connect(self, cfg: SerialConfig) -> None:
-        drv = DPetteDriver(cfg)
-        with pytest.raises(RuntimeError, match="Not connected"):
-            drv.identify()
-
     def test_aspirate_requires_connect(self, cfg: SerialConfig) -> None:
         drv = DPetteDriver(cfg)
         with pytest.raises(RuntimeError, match="Not connected"):
             drv.aspirate()
 
+    def test_dispense_requires_connect(self, cfg: SerialConfig) -> None:
+        drv = DPetteDriver(cfg)
+        with pytest.raises(RuntimeError, match="Not connected"):
+            drv.dispense()
+
     def test_handshake_requires_connect(self, cfg: SerialConfig) -> None:
         drv = DPetteDriver(cfg)
         with pytest.raises(RuntimeError, match="Not connected"):
             drv.handshake()
+
+    def test_eject_tip_requires_connect(self, cfg: SerialConfig) -> None:
+        drv = DPetteDriver(cfg)
+        with pytest.raises(RuntimeError, match="Not connected"):
+            drv.eject_tip()
 
 
 class TestConnect:
@@ -77,20 +84,55 @@ class TestConnect:
     ) -> None:
         drv = DPetteDriver(cfg)
         drv.connect()
-        # Should have written: handshake, then B0 prime
         writes = [call[0][0] for call in mock_serial.write.call_args_list]
         assert len(writes) == 2
         assert writes[0] == bytes.fromhex("fe a5 00 00 00 a5")  # handshake
         assert writes[1] == bytes.fromhex("fe b0 01 00 00 b1")  # B0 prime
 
-    def test_connect_timeout_closes_port(
-        self, cfg: SerialConfig, mock_serial: MagicMock
-    ) -> None:
-        mock_serial.read.return_value = b""  # no response
-        drv = DPetteDriver(cfg)
-        with pytest.raises(TimeoutError):
+    def test_connect_stub_mode_on_failure(self, cfg: SerialConfig) -> None:
+        """Connection failure enters stub mode instead of raising."""
+        with patch("dpette.serial_link.serial.Serial", side_effect=OSError("no port")):
+            drv = DPetteDriver(cfg)
             drv.connect()
-        mock_serial.close.assert_called()
+            assert drv.stub_mode
+            assert drv._connected
+
+
+class TestStubMode:
+    """Stub mode: all methods succeed without hardware."""
+
+    def test_stub_aspirate(self, cfg: SerialConfig) -> None:
+        with patch("dpette.serial_link.serial.Serial", side_effect=OSError):
+            drv = DPetteDriver(cfg)
+            drv.connect()
+            result = drv.aspirate(100.0)
+            assert result is None
+
+    def test_stub_dispense(self, cfg: SerialConfig) -> None:
+        with patch("dpette.serial_link.serial.Serial", side_effect=OSError):
+            drv = DPetteDriver(cfg)
+            drv.connect()
+            result = drv.dispense(100.0)
+            assert result is None
+
+    def test_stub_eject_tip(self, cfg: SerialConfig) -> None:
+        with patch("dpette.serial_link.serial.Serial", side_effect=OSError):
+            drv = DPetteDriver(cfg)
+            drv.connect()
+            drv.eject_tip()  # should not raise
+
+    def test_stub_set_volume(self, cfg: SerialConfig) -> None:
+        with patch("dpette.serial_link.serial.Serial", side_effect=OSError):
+            drv = DPetteDriver(cfg)
+            drv.connect()
+            result = drv.set_volume(200.0)
+            assert result is None
+
+    def test_stub_disconnect(self, cfg: SerialConfig) -> None:
+        with patch("dpette.serial_link.serial.Serial", side_effect=OSError):
+            drv = DPetteDriver(cfg)
+            drv.connect()
+            drv.disconnect()  # should not raise
 
 
 class TestHandshake:
@@ -99,6 +141,7 @@ class TestHandshake:
     ) -> None:
         mock_serial.read.return_value = HANDSHAKE_RX
         pkt = connected_driver.handshake()
+        assert pkt is not None
         assert pkt.cmd == Command.HANDSHAKE
 
 
@@ -108,13 +151,10 @@ class TestSendCaliVolume:
     ) -> None:
         mock_serial.read.return_value = CALI_VOL_RX
         pkt = connected_driver.send_cali_volume(1000)
+        assert pkt is not None
         assert pkt.cmd == Command.SEND_CALI_VOLUME
         written = mock_serial.write.call_args[0][0]
         assert written == bytes.fromhex("fe a6 27 10 00 dd")
-
-
-ASPIRATE_RX_DOUBLE = bytes.fromhex("fd b3 00 00 00 b3 fd b3 01 00 00 b4")
-DISPENSE_RX = bytes.fromhex("fd b0 00 00 00 b0")
 
 
 class TestAspirate:
@@ -131,8 +171,16 @@ class TestAspirate:
     ) -> None:
         mock_serial.read.return_value = ASPIRATE_RX_DOUBLE
         pkt = connected_driver.aspirate()
+        assert pkt is not None
         assert pkt.cmd == Command.ASPIRATE
-        assert pkt.b2 == 0x01  # completed
+        assert pkt.b2 == 0x01
+
+    def test_aspirate_with_volume_param(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.return_value = ASPIRATE_RX_DOUBLE
+        pkt = connected_driver.aspirate(100.0)
+        assert pkt is not None
 
     def test_aspirate_increments_cycle_count(
         self, connected_driver: DPetteDriver, mock_serial: MagicMock
@@ -156,10 +204,27 @@ class TestDispense:
     ) -> None:
         mock_serial.read.return_value = DISPENSE_RX
         pkt = connected_driver.dispense()
+        assert pkt is not None
         assert pkt.cmd == Command.DISPENSE
 
+    def test_dispense_with_volume_param(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.return_value = DISPENSE_RX
+        pkt = connected_driver.dispense(100.0)
+        assert pkt is not None
 
-class TestSafetyIntegration:
+
+class TestSetVolume:
+    def test_set_volume_sends_a6(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.return_value = CALI_VOL_RX
+        pkt = connected_driver.set_volume(200.0)
+        assert pkt is not None
+        written = mock_serial.write.call_args[0][0]
+        assert written == bytes.fromhex("fe a6 07 d0 00 7d")
+
     def test_negative_volume_rejected(self, connected_driver: DPetteDriver) -> None:
         with pytest.raises(SafetyError, match="positive"):
             connected_driver.set_volume(-5.0)
@@ -167,6 +232,22 @@ class TestSafetyIntegration:
     def test_excessive_volume_rejected(self, connected_driver: DPetteDriver) -> None:
         with pytest.raises(SafetyError, match="exceeds maximum"):
             connected_driver.set_volume(99999.0)
+
+
+class TestEjectTip:
+    def test_eject_tip_raises_not_implemented(
+        self, connected_driver: DPetteDriver
+    ) -> None:
+        with pytest.raises(NotImplementedError, match="BSS138"):
+            connected_driver.eject_tip()
+
+
+class TestTriggerButton:
+    def test_trigger_button_raises_not_implemented(
+        self, connected_driver: DPetteDriver
+    ) -> None:
+        with pytest.raises(NotImplementedError, match="BSS138"):
+            connected_driver.trigger_button()
 
 
 class TestCycleLimit:

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -1,6 +1,6 @@
 """Tests for the high-level DPetteDriver API.
 
-Uses mock serial ports — no hardware needed.
+Uses mock serial ports -- no hardware needed.
 """
 
 from __future__ import annotations
@@ -15,14 +15,24 @@ import pytest
 
 from dpette.config import SerialConfig
 from dpette.driver import MAX_CONTIGUOUS_CYCLES, DPetteDriver
-from dpette.protocol import Command
+from dpette.protocol import Command, KeyAction, WorkingMode
 from dpette.safety import SafetyError
 
 # Canned response bytes for mocking
-HANDSHAKE_RX = bytes.fromhex("fd a5 00 00 00 a5")
+HELLO_RX = bytes.fromhex("fd a0 00 00 00 a0")
+WOL_RX = bytes.fromhex("fd b0 00 00 00 b0")
+PI_VOLUM_RX = bytes.fromhex("fd b2 00 00 00 b2")
+SPEED_RX = bytes.fromhex("fd b1 00 00 00 b1")
+KEY_SUCK_ACK = bytes.fromhex("fd b3 00 00 00 b3")
+KEY_SUCK_DONE = bytes.fromhex("fd b3 01 00 00 b4")
+KEY_BLOW_ACK = bytes.fromhex("fd b3 00 00 00 b3")
+KEY_BLOW_DONE = bytes.fromhex("fd b3 02 00 00 b5")
+ST_VOLUM_RX = bytes.fromhex("fd b4 00 00 00 b4")
+ST_NUM_RX = bytes.fromhex("fd b5 00 00 00 b5")
+DI1_VOLUM_RX = bytes.fromhex("fd b6 00 00 00 b6")
+DI2_VOLUM_RX = bytes.fromhex("fd b7 00 00 00 b7")
+DEMARCATE_RX = bytes.fromhex("fd a5 00 00 00 a5")
 CALI_VOL_RX = bytes.fromhex("fd a6 00 00 00 a6")
-ASPIRATE_RX_DOUBLE = bytes.fromhex("fd b3 00 00 00 b3 fd b3 01 00 00 b4")
-DISPENSE_RX = bytes.fromhex("fd b0 00 00 00 b0")
 
 
 @pytest.fixture()
@@ -32,20 +42,24 @@ def cfg() -> SerialConfig:
 
 @pytest.fixture()
 def mock_serial() -> Generator[MagicMock, None, None]:
-    """Yield a mock serial.Serial that returns handshake ACK by default."""
+    """Yield a mock serial.Serial that returns HELLO + WOL ACKs for connect."""
     with patch("dpette.serial_link.serial.Serial") as cls:
         port = MagicMock()
         port.is_open = True
-        port.read.return_value = HANDSHAKE_RX
+        port.in_waiting = 0  # flush_input finds nothing to discard
+        port.read.side_effect = [HELLO_RX, WOL_RX]
         cls.return_value = port
         yield port
 
 
 @pytest.fixture()
 def connected_driver(cfg: SerialConfig, mock_serial: MagicMock) -> DPetteDriver:
-    """A driver that has already connected via mock."""
+    """A driver that has already connected via mock (A0 + B0 consumed)."""
     drv = DPetteDriver(cfg)
     drv.connect()
+    # Reset side_effect so tests can set their own
+    mock_serial.read.side_effect = None
+    mock_serial.read.return_value = b""
     return drv
 
 
@@ -59,11 +73,6 @@ class TestDriverRequiresConnection:
         drv = DPetteDriver(cfg)
         with pytest.raises(RuntimeError, match="Not connected"):
             drv.dispense()
-
-    def test_handshake_requires_connect(self, cfg: SerialConfig) -> None:
-        drv = DPetteDriver(cfg)
-        with pytest.raises(RuntimeError, match="Not connected"):
-            drv.handshake()
 
     def test_eject_tip_requires_connect(self, cfg: SerialConfig) -> None:
         drv = DPetteDriver(cfg)
@@ -79,18 +88,18 @@ class TestConnect:
         drv.connect()
         assert drv._connected
 
-    def test_connect_sends_handshake_and_prime(
+    def test_connect_sends_hello_and_enters_pi(
         self, cfg: SerialConfig, mock_serial: MagicMock
     ) -> None:
         drv = DPetteDriver(cfg)
         drv.connect()
         writes = [call[0][0] for call in mock_serial.write.call_args_list]
         assert len(writes) == 2
-        assert writes[0] == bytes.fromhex("fe a5 00 00 00 a5")  # handshake
-        assert writes[1] == bytes.fromhex("fe b0 01 00 00 b1")  # B0 prime
+        assert writes[0] == bytes.fromhex("fe a0 00 00 00 a0")  # A0 hello
+        assert writes[1] == bytes.fromhex("fe b0 01 00 00 b1")  # B0 PI mode
+        assert drv.mode == WorkingMode.PI
 
     def test_connect_stub_mode_on_failure(self, cfg: SerialConfig) -> None:
-        """Connection failure enters stub mode instead of raising."""
         with patch("dpette.serial_link.serial.Serial", side_effect=OSError("no port")):
             drv = DPetteDriver(cfg)
             drv.connect()
@@ -99,8 +108,6 @@ class TestConnect:
 
 
 class TestStubMode:
-    """Stub mode: all methods succeed without hardware."""
-
     def test_stub_aspirate(self, cfg: SerialConfig) -> None:
         with patch("dpette.serial_link.serial.Serial", side_effect=OSError):
             drv = DPetteDriver(cfg)
@@ -119,7 +126,7 @@ class TestStubMode:
         with patch("dpette.serial_link.serial.Serial", side_effect=OSError):
             drv = DPetteDriver(cfg)
             drv.connect()
-            drv.eject_tip()  # should not raise
+            drv.eject_tip()
 
     def test_stub_set_volume(self, cfg: SerialConfig) -> None:
         with patch("dpette.serial_link.serial.Serial", side_effect=OSError):
@@ -132,98 +139,153 @@ class TestStubMode:
         with patch("dpette.serial_link.serial.Serial", side_effect=OSError):
             drv = DPetteDriver(cfg)
             drv.connect()
-            drv.disconnect()  # should not raise
+            drv.disconnect()
+
+    def test_stub_enter_mode(self, cfg: SerialConfig) -> None:
+        with patch("dpette.serial_link.serial.Serial", side_effect=OSError):
+            drv = DPetteDriver(cfg)
+            drv.connect()
+            drv.enter_mode(WorkingMode.PI)
+            assert drv.mode == WorkingMode.PI
+
+    def test_stub_mix(self, cfg: SerialConfig) -> None:
+        with patch("dpette.serial_link.serial.Serial", side_effect=OSError):
+            drv = DPetteDriver(cfg)
+            drv.connect()
+            drv.mix_aspirate(100.0)
+            drv.mix_dispense()
+
+    def test_stub_split(self, cfg: SerialConfig) -> None:
+        with patch("dpette.serial_link.serial.Serial", side_effect=OSError):
+            drv = DPetteDriver(cfg)
+            drv.connect()
+            drv.split_setup(100.0, count=3)
+            drv.split_aspirate()
+            drv.split_dispense()
+
+    def test_stub_dilute(self, cfg: SerialConfig) -> None:
+        with patch("dpette.serial_link.serial.Serial", side_effect=OSError):
+            drv = DPetteDriver(cfg)
+            drv.connect()
+            drv.dilute_setup(100.0, 200.0)
+            drv.dilute_aspirate()
+            drv.dilute_dispense()
 
 
-class TestHandshake:
-    def test_handshake_returns_packet(
+class TestEnterMode:
+    def test_enter_pi_mode(
         self, connected_driver: DPetteDriver, mock_serial: MagicMock
     ) -> None:
-        mock_serial.read.return_value = HANDSHAKE_RX
-        pkt = connected_driver.handshake()
-        assert pkt is not None
-        assert pkt.cmd == Command.HANDSHAKE
-
-
-class TestSendCaliVolume:
-    def test_sends_encoded_volume(
-        self, connected_driver: DPetteDriver, mock_serial: MagicMock
-    ) -> None:
-        mock_serial.read.return_value = CALI_VOL_RX
-        pkt = connected_driver.send_cali_volume(1000)
-        assert pkt is not None
-        assert pkt.cmd == Command.SEND_CALI_VOLUME
+        mock_serial.read.return_value = WOL_RX
+        connected_driver.enter_mode(WorkingMode.PI)
         written = mock_serial.write.call_args[0][0]
-        assert written == bytes.fromhex("fe a6 27 10 00 dd")
+        assert written == bytes.fromhex("fe b0 01 00 00 b1")
+        assert connected_driver.mode == WorkingMode.PI
+
+    def test_enter_st_mode(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.return_value = WOL_RX
+        connected_driver.enter_mode(WorkingMode.ST)
+        written = mock_serial.write.call_args[0][0]
+        assert written == bytes.fromhex("fe b0 02 00 00 b2")
+        assert connected_driver.mode == WorkingMode.ST
+
+    def test_enter_di_mode(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.return_value = WOL_RX
+        connected_driver.enter_mode(WorkingMode.DI)
+        written = mock_serial.write.call_args[0][0]
+        assert written == bytes.fromhex("fe b0 03 00 00 b3")
+        assert connected_driver.mode == WorkingMode.DI
+
+
+class TestSetSpeed:
+    def test_set_suck_speed(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.return_value = SPEED_RX
+        connected_driver.set_speed(KeyAction.SUCK, 2)
+        written = mock_serial.write.call_args[0][0]
+        assert written == bytes.fromhex("fe b1 01 02 00 b4")
+
+    def test_set_blow_speed(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.return_value = SPEED_RX
+        connected_driver.set_speed(KeyAction.BLOW, 3)
+        written = mock_serial.write.call_args[0][0]
+        assert written == bytes.fromhex("fe b1 02 03 00 b6")
+
+    def test_invalid_speed_rejected(self, connected_driver: DPetteDriver) -> None:
+        with pytest.raises(SafetyError):
+            connected_driver.set_speed(KeyAction.SUCK, 5)
 
 
 class TestAspirate:
-    def test_aspirate_sends_b3_01(
+    def test_aspirate_sends_b3_suck(
         self, connected_driver: DPetteDriver, mock_serial: MagicMock
     ) -> None:
-        mock_serial.read.return_value = ASPIRATE_RX_DOUBLE
+        mock_serial.read.side_effect = [KEY_SUCK_ACK, KEY_SUCK_DONE]
         connected_driver.aspirate()
         written = mock_serial.write.call_args[0][0]
         assert written == bytes.fromhex("fe b3 01 00 00 b4")
 
+    def test_aspirate_with_volume_sends_b2(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.side_effect = [PI_VOLUM_RX, KEY_SUCK_ACK, KEY_SUCK_DONE]
+        connected_driver.aspirate(200.0)
+        writes = [c[0][0] for c in mock_serial.write.call_args_list]
+        assert writes[-2] == bytes.fromhex("fe b2 00 4e 20 20")
+        assert writes[-1] == bytes.fromhex("fe b3 01 00 00 b4")
+
     def test_aspirate_returns_completed_packet(
         self, connected_driver: DPetteDriver, mock_serial: MagicMock
     ) -> None:
-        mock_serial.read.return_value = ASPIRATE_RX_DOUBLE
+        mock_serial.read.side_effect = [KEY_SUCK_ACK, KEY_SUCK_DONE]
         pkt = connected_driver.aspirate()
         assert pkt is not None
-        assert pkt.cmd == Command.ASPIRATE
+        assert pkt.cmd == Command.KEY
         assert pkt.b2 == 0x01
-
-    def test_aspirate_with_volume_param(
-        self, connected_driver: DPetteDriver, mock_serial: MagicMock
-    ) -> None:
-        mock_serial.read.return_value = ASPIRATE_RX_DOUBLE
-        pkt = connected_driver.aspirate(100.0)
-        assert pkt is not None
 
     def test_aspirate_increments_cycle_count(
         self, connected_driver: DPetteDriver, mock_serial: MagicMock
     ) -> None:
-        mock_serial.read.return_value = ASPIRATE_RX_DOUBLE
+        mock_serial.read.side_effect = [KEY_SUCK_ACK, KEY_SUCK_DONE]
         connected_driver.aspirate()
         assert connected_driver._cycle_count == 1
 
 
 class TestDispense:
-    def test_dispense_sends_b0_01(
+    def test_dispense_sends_b3_blow(
         self, connected_driver: DPetteDriver, mock_serial: MagicMock
     ) -> None:
-        mock_serial.read.return_value = DISPENSE_RX
+        mock_serial.read.side_effect = [KEY_BLOW_ACK, KEY_BLOW_DONE]
         connected_driver.dispense()
         written = mock_serial.write.call_args[0][0]
-        assert written == bytes.fromhex("fe b0 01 00 00 b1")
+        assert written == bytes.fromhex("fe b3 02 00 00 b5")
 
-    def test_dispense_returns_packet(
+    def test_dispense_returns_completed_packet(
         self, connected_driver: DPetteDriver, mock_serial: MagicMock
     ) -> None:
-        mock_serial.read.return_value = DISPENSE_RX
+        mock_serial.read.side_effect = [KEY_BLOW_ACK, KEY_BLOW_DONE]
         pkt = connected_driver.dispense()
         assert pkt is not None
-        assert pkt.cmd == Command.DISPENSE
-
-    def test_dispense_with_volume_param(
-        self, connected_driver: DPetteDriver, mock_serial: MagicMock
-    ) -> None:
-        mock_serial.read.return_value = DISPENSE_RX
-        pkt = connected_driver.dispense(100.0)
-        assert pkt is not None
+        assert pkt.cmd == Command.KEY
+        assert pkt.b2 == 0x02
 
 
 class TestSetVolume:
-    def test_set_volume_sends_a6(
+    def test_set_volume_sends_b2(
         self, connected_driver: DPetteDriver, mock_serial: MagicMock
     ) -> None:
-        mock_serial.read.return_value = CALI_VOL_RX
+        mock_serial.read.return_value = PI_VOLUM_RX
         pkt = connected_driver.set_volume(200.0)
         assert pkt is not None
         written = mock_serial.write.call_args[0][0]
-        assert written == bytes.fromhex("fe a6 07 d0 00 7d")
+        assert written == bytes.fromhex("fe b2 00 4e 20 20")
 
     def test_negative_volume_rejected(self, connected_driver: DPetteDriver) -> None:
         with pytest.raises(SafetyError, match="positive"):
@@ -234,6 +296,108 @@ class TestSetVolume:
             connected_driver.set_volume(99999.0)
 
 
+class TestCalibration:
+    def test_demarcate_sends_a5(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.return_value = DEMARCATE_RX
+        pkt = connected_driver.demarcate(0)
+        assert pkt is not None
+        written = mock_serial.write.call_args[0][0]
+        assert written == bytes.fromhex("fe a5 00 00 00 a5")
+
+    def test_set_cali_volume_sends_a6(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.return_value = CALI_VOL_RX
+        pkt = connected_driver.set_cali_volume(1000)
+        assert pkt is not None
+        written = mock_serial.write.call_args[0][0]
+        assert written == bytes.fromhex("fe a6 27 10 00 dd")
+
+
+class TestSplit:
+    def test_split_setup_sends_mode_volume_count(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.side_effect = [WOL_RX, ST_VOLUM_RX, ST_NUM_RX]
+        connected_driver.split_setup(100.0, count=3)
+        writes = [c[0][0] for c in mock_serial.write.call_args_list]
+        assert writes[-3] == bytes.fromhex("fe b0 02 00 00 b2")  # ST mode
+        assert writes[-2] == bytes.fromhex("fe b4 00 27 10 eb")  # 100 uL
+        assert writes[-1] == bytes.fromhex("fe b5 03 00 00 b8")  # 3 splits
+
+    def test_split_aspirate_sends_suck(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.side_effect = [KEY_SUCK_ACK, KEY_SUCK_DONE]
+        connected_driver.split_aspirate()
+        written = mock_serial.write.call_args[0][0]
+        assert written == bytes.fromhex("fe b3 01 00 00 b4")
+
+    def test_split_dispense_sends_blow(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.side_effect = [KEY_BLOW_ACK, KEY_BLOW_DONE]
+        connected_driver.split_dispense()
+        written = mock_serial.write.call_args[0][0]
+        assert written == bytes.fromhex("fe b3 02 00 00 b5")
+
+
+class TestDilute:
+    def test_dilute_setup_sends_mode_and_volumes(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.side_effect = [WOL_RX, DI1_VOLUM_RX, DI2_VOLUM_RX]
+        connected_driver.dilute_setup(200.0, 100.0)
+        writes = [c[0][0] for c in mock_serial.write.call_args_list]
+        assert writes[-3] == bytes.fromhex("fe b0 03 00 00 b3")  # DI mode
+        assert writes[-2] == bytes.fromhex("fe b6 00 4e 20 24")  # 200 uL
+        assert writes[-1] == bytes.fromhex("fe b7 00 27 10 ee")  # 100 uL
+
+    def test_dilute_aspirate_sends_suck(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.side_effect = [KEY_SUCK_ACK, KEY_SUCK_DONE]
+        connected_driver.dilute_aspirate()
+        written = mock_serial.write.call_args[0][0]
+        assert written == bytes.fromhex("fe b3 01 00 00 b4")
+
+    def test_dilute_dispense_sends_blow(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.side_effect = [KEY_BLOW_ACK, KEY_BLOW_DONE]
+        connected_driver.dilute_dispense()
+        written = mock_serial.write.call_args[0][0]
+        assert written == bytes.fromhex("fe b3 02 00 00 b5")
+
+
+class TestMix:
+    def test_mix_aspirate_sends_speed_volume_suck(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.side_effect = [
+            SPEED_RX,  # B1 suck speed
+            SPEED_RX,  # B1 blow speed
+            PI_VOLUM_RX,  # B2 volume
+            KEY_SUCK_ACK,
+            KEY_SUCK_DONE,
+        ]
+        pkt = connected_driver.mix_aspirate(100.0, speed=3)
+        writes = [c[0][0] for c in mock_serial.write.call_args_list]
+        assert writes[-1] == bytes.fromhex("fe b3 01 00 00 b4")  # B3 suck
+        assert pkt.b2 == 0x01
+
+    def test_mix_dispense_sends_blow(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
+        mock_serial.read.side_effect = [KEY_BLOW_ACK, KEY_BLOW_DONE]
+        pkt = connected_driver.mix_dispense()
+        written = mock_serial.write.call_args[0][0]
+        assert written == bytes.fromhex("fe b3 02 00 00 b5")
+        assert pkt.b2 == 0x02
+
+
 class TestEjectTip:
     def test_eject_tip_raises_not_implemented(
         self, connected_driver: DPetteDriver
@@ -242,16 +406,10 @@ class TestEjectTip:
             connected_driver.eject_tip()
 
 
-class TestTriggerButton:
-    def test_trigger_button_raises_not_implemented(
-        self, connected_driver: DPetteDriver
-    ) -> None:
-        with pytest.raises(NotImplementedError, match="BSS138"):
-            connected_driver.trigger_button()
-
-
 class TestCycleLimit:
-    def test_cycle_limit_enforced(self, connected_driver: DPetteDriver) -> None:
+    def test_cycle_limit_enforced(
+        self, connected_driver: DPetteDriver, mock_serial: MagicMock
+    ) -> None:
         connected_driver._cycle_count = MAX_CONTIGUOUS_CYCLES
         with pytest.raises(RuntimeError, match="contiguous cycles"):
             connected_driver.aspirate()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,6 +1,7 @@
 """Tests for protocol encoding / decoding.
 
-Uses real packet fixtures captured from live hardware (2026-04-06).
+Uses real packet fixtures captured from live hardware (2026-04-06)
+and confirmed against official DLAB protocol (2026-04-09).
 """
 
 from __future__ import annotations
@@ -12,32 +13,45 @@ from dpette.protocol import (
     HEADER_TX,
     PACKET_LEN,
     Command,
-    aspirate_packet,
+    KeyAction,
+    WorkingMode,
     compute_checksum,
     decode_packet,
-    dispense_packet,
+    demarcate_packet,
+    di1_volume_packet,
+    di2_volume_packet,
     encode_packet,
-    handshake_packet,
+    hello_packet,
+    key_packet,
+    pi_volume_packet,
     read_ee_packet,
     send_cali_volume_packet,
+    speed_packet,
+    st_num_packet,
+    st_volume_packet,
+    wol_packet,
     write_ee_packet,
 )
 
 # -- Real packets captured from live hardware --------------------------------
 
-HANDSHAKE_TX = bytes.fromhex("fe a5 00 00 00 a5")
-HANDSHAKE_RX = bytes.fromhex("fd a5 00 00 00 a5")
+HELLO_TX = bytes.fromhex("fe a0 00 00 00 a0")
+HELLO_RX = bytes.fromhex("fd a0 00 00 00 a0")
+DEMARCATE_TX = bytes.fromhex("fe a5 00 00 00 a5")
+DEMARCATE_RX = bytes.fromhex("fd a5 00 00 00 a5")
 CALI_VOL_1000_TX = bytes.fromhex("fe a6 27 10 00 dd")
 CALI_VOL_1000_RX = bytes.fromhex("fd a6 00 00 00 a6")
 WRITE_EE_RX = bytes.fromhex("fd a4 00 00 00 a4")
 
 
 class TestComputeChecksum:
-    def test_handshake(self) -> None:
+    def test_hello(self) -> None:
+        assert compute_checksum(0xA0, 0, 0, 0) == 0xA0
+
+    def test_demarcate(self) -> None:
         assert compute_checksum(0xA5, 0, 0, 0) == 0xA5
 
     def test_cali_volume_1000(self) -> None:
-        # 1000 µL × 10 = 10000 = 0x2710
         assert compute_checksum(0xA6, 0x27, 0x10, 0x00) == 0xDD
 
     def test_wraps_at_8_bits(self) -> None:
@@ -45,14 +59,14 @@ class TestComputeChecksum:
 
 
 class TestEncodePacket:
-    def test_handshake(self) -> None:
-        assert encode_packet(Command.HANDSHAKE) == HANDSHAKE_TX
+    def test_hello(self) -> None:
+        assert encode_packet(Command.HELLO) == HELLO_TX
 
     def test_length_is_always_6(self) -> None:
-        assert len(encode_packet(Command.HANDSHAKE)) == PACKET_LEN
+        assert len(encode_packet(Command.HELLO)) == PACKET_LEN
 
     def test_header_is_fe(self) -> None:
-        pkt = encode_packet(Command.HANDSHAKE)
+        pkt = encode_packet(Command.HELLO)
         assert pkt[0] == HEADER_TX
 
     def test_payload_bytes(self) -> None:
@@ -61,26 +75,27 @@ class TestEncodePacket:
 
 
 class TestDecodePacket:
-    def test_handshake_response(self) -> None:
-        pkt = decode_packet(HANDSHAKE_RX)
+    def test_hello_response(self) -> None:
+        pkt = decode_packet(HELLO_RX)
         assert pkt.header == HEADER_RX
-        assert pkt.cmd == Command.HANDSHAKE
+        assert pkt.cmd == Command.HELLO
         assert pkt.payload == (0, 0, 0)
+
+    def test_demarcate_response(self) -> None:
+        pkt = decode_packet(DEMARCATE_RX)
+        assert pkt.cmd == Command.DEMARCATE
 
     def test_cali_volume_response(self) -> None:
         pkt = decode_packet(CALI_VOL_1000_RX)
-        assert pkt.cmd == Command.SEND_CALI_VOLUME
-        assert pkt.b2 == 0
-        assert pkt.b3 == 0
-        assert pkt.b4 == 0
+        assert pkt.cmd == Command.DMRCT_VOLUM
 
     def test_write_ee_response(self) -> None:
         pkt = decode_packet(WRITE_EE_RX)
-        assert pkt.cmd == Command.WRITE_EE
+        assert pkt.cmd == Command.EE_WRITE
 
     def test_raw_roundtrip(self) -> None:
-        pkt = decode_packet(HANDSHAKE_RX)
-        assert pkt.raw == HANDSHAKE_RX
+        pkt = decode_packet(HELLO_RX)
+        assert pkt.raw == HELLO_RX
 
     def test_wrong_length_raises(self) -> None:
         with pytest.raises(ValueError, match="Expected 6"):
@@ -95,13 +110,20 @@ class TestDecodePacket:
             decode_packet(b"\xfd\xa5\x00\x00\x00\xff")
 
 
-class TestHandshakePacket:
-    def test_default_param(self) -> None:
-        assert handshake_packet() == HANDSHAKE_TX
+class TestHelloPacket:
+    def test_bytes(self) -> None:
+        assert hello_packet() == HELLO_TX
 
-    def test_start_calibrate(self) -> None:
-        pkt = handshake_packet(param=1)
-        assert pkt == bytes.fromhex("fe a5 01 00 00 a6")
+    def test_cmd_byte(self) -> None:
+        assert hello_packet()[1] == Command.HELLO
+
+
+class TestDemarcatePacket:
+    def test_exit_cal(self) -> None:
+        assert demarcate_packet(0) == DEMARCATE_TX
+
+    def test_enter_cal(self) -> None:
+        assert demarcate_packet(1) == bytes.fromhex("fe a5 01 00 00 a6")
 
 
 class TestSendCaliVolumePacket:
@@ -109,24 +131,21 @@ class TestSendCaliVolumePacket:
         assert send_cali_volume_packet(1000) == CALI_VOL_1000_TX
 
     def test_100ul(self) -> None:
-        # 100 × 10 = 1000 = 0x03E8
         pkt = send_cali_volume_packet(100)
         assert pkt == bytes.fromhex("fe a6 03 e8 00 91")
 
     def test_500ul(self) -> None:
-        # 500 × 10 = 5000 = 0x1388
         pkt = send_cali_volume_packet(500)
         assert pkt == bytes.fromhex("fe a6 13 88 00 41")
 
 
 class TestReadEePacket:
     def test_addr_in_b3(self) -> None:
-        """Address goes in byte[3] — confirmed from PetteCali capture."""
         pkt = read_ee_packet(0x90)
         assert pkt == bytes.fromhex("fe a3 00 90 00 33")
 
     def test_cmd_is_a3(self) -> None:
-        assert read_ee_packet(0x80)[1] == Command.DATA
+        assert read_ee_packet(0x80)[1] == Command.EE_READ
 
     def test_b2_is_zero(self) -> None:
         assert read_ee_packet(0x82)[2] == 0x00
@@ -134,7 +153,6 @@ class TestReadEePacket:
 
 class TestWriteEePacket:
     def test_addr_in_b3_value_in_b4(self) -> None:
-        """Address in byte[3], value in byte[4] — from PetteCali capture."""
         pkt = write_ee_packet(0x92, value=0x2F)
         assert pkt == bytes.fromhex("fe a4 00 92 2f 65")
 
@@ -148,23 +166,61 @@ class TestWriteEePacket:
         assert write_ee_packet(0x90, 0xAB)[4] == 0xAB
 
 
-class TestAspiratePacket:
-    def test_bytes(self) -> None:
-        assert aspirate_packet() == bytes.fromhex("fe b3 01 00 00 b4")
+class TestWolPacket:
+    def test_pi_mode(self) -> None:
+        assert wol_packet(WorkingMode.PI) == bytes.fromhex("fe b0 01 00 00 b1")
 
-    def test_cmd_byte(self) -> None:
-        assert aspirate_packet()[1] == Command.ASPIRATE
+    def test_st_mode(self) -> None:
+        assert wol_packet(WorkingMode.ST) == bytes.fromhex("fe b0 02 00 00 b2")
 
-    def test_b2_is_trigger(self) -> None:
-        assert aspirate_packet()[2] == 0x01
+    def test_di_mode(self) -> None:
+        assert wol_packet(WorkingMode.DI) == bytes.fromhex("fe b0 03 00 00 b3")
 
 
-class TestDispensePacket:
-    def test_bytes(self) -> None:
-        assert dispense_packet() == bytes.fromhex("fe b0 01 00 00 b1")
+class TestSpeedPacket:
+    def test_suck_speed_2(self) -> None:
+        assert speed_packet(1, 2) == bytes.fromhex("fe b1 01 02 00 b4")
 
-    def test_cmd_byte(self) -> None:
-        assert dispense_packet()[1] == Command.DISPENSE
+    def test_blow_speed_3(self) -> None:
+        assert speed_packet(2, 3) == bytes.fromhex("fe b1 02 03 00 b6")
 
-    def test_b2_is_trigger(self) -> None:
-        assert dispense_packet()[2] == 0x01
+
+class TestPiVolumePacket:
+    def test_200ul(self) -> None:
+        # 200 * 100 = 20000 = 0x004E20
+        assert pi_volume_packet(200.0) == bytes.fromhex("fe b2 00 4e 20 20")
+
+    def test_50ul(self) -> None:
+        # 50 * 100 = 5000 = 0x001388
+        assert pi_volume_packet(50.0) == bytes.fromhex("fe b2 00 13 88 4d")
+
+    def test_1000ul(self) -> None:
+        # 1000 * 100 = 100000 = 0x0186A0
+        assert pi_volume_packet(1000.0) == bytes.fromhex("fe b2 01 86 a0 d9")
+
+
+class TestKeyPacket:
+    def test_suck(self) -> None:
+        assert key_packet(KeyAction.SUCK) == bytes.fromhex("fe b3 01 00 00 b4")
+
+    def test_blow(self) -> None:
+        assert key_packet(KeyAction.BLOW) == bytes.fromhex("fe b3 02 00 00 b5")
+
+
+class TestStVolumePacket:
+    def test_100ul(self) -> None:
+        # 100 * 100 = 10000 = 0x002710
+        assert st_volume_packet(100.0) == bytes.fromhex("fe b4 00 27 10 eb")
+
+
+class TestStNumPacket:
+    def test_5_splits(self) -> None:
+        assert st_num_packet(5) == bytes.fromhex("fe b5 05 00 00 ba")
+
+
+class TestDiVolumePackets:
+    def test_di1_200ul(self) -> None:
+        assert di1_volume_packet(200.0) == bytes.fromhex("fe b6 00 4e 20 24")
+
+    def test_di2_100ul(self) -> None:
+        assert di2_volume_packet(100.0) == bytes.fromhex("fe b7 00 27 10 ee")


### PR DESCRIPTION
## Summary

- **Remote volume control confirmed** (EXP-050): B2 (PI_VOLUM) controls actual motor travel via volume×100 24-bit encoding. Tested at 50 and 200 µL with dial at 300 — liquid matched B2, not the dial. No MOSFET or hardware modification needed.
- **Complete protocol rewrite** from official DLAB Communication_Protocol_CN.doc (discovered in xg590/Learn_dPettePlus repo): A0 handshake, B0 mode selection (PI/ST/DI), B1 speed, B2 volume, B3 suck/blow
- **Three operating modes**: PI (pipetting), ST (splitting), DI (dilution) — all hardware-confirmed in EXP-049 through EXP-053
- **Split API into caller-controlled steps** to avoid piston return suction: mix_aspirate/mix_dispense, split_setup/split_aspirate/split_dispense, dilute_setup/dilute_aspirate/dilute_dispense
- **DI mode workaround**: blow doesn't trigger motor on basic dPette — enter_mode(PI) homes motor and expels liquid
- **94 tests passing**, up from 56

## Key protocol corrections

| What we thought | What it actually is |
|---|---|
| A5 = handshake | A5 = calibration mode (DEMARCATE) |
| A0 = unknown | A0 = real handshake (HELLO) |
| B0 = dispense | B0 = enter working mode (PI/ST/DI) |
| B3 = aspirate only | B3 b2=1 aspirate, b2=2 dispense |
| B2 = no effect | B2 = volume control (×100, 24-bit) |

Overturns the EXP-044 "FINAL CONCLUSION" that serial-only volume control is impossible.

## Test plan

- [x] EXP-049: All official protocol commands accepted on hardware
- [x] EXP-050: B2 volume control verified (50/200 µL with dial at 300)
- [x] EXP-051: Mix cycle timing (speed 1-3, ~1.8s/cycle at max)
- [x] EXP-052: PI aspirate/dispense, volume switching, speed control
- [x] EXP-052b: Mix, split, dilution with tip position control
- [x] EXP-053: DI mode with PI dispense workaround
- [x] 94 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)