### PR TITLE
Update README and examples for official protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,270 +1,181 @@
 ---
 title: "dpette-usb-driver"
 status: "ACTIVE"
-updated: "2026-04-07"
+updated: "2026-04-09"
 owner: "lambda biolab"
 ---
 
 # dpette-usb-driver
 
-Reverse-engineered USB/serial driver for **DLAB dPette** and **dPette+** electronic pipettes.
+Open-source Python driver for **DLAB dPette** and **dPette+** electronic
+pipettes. Full serial volume control, speed control, and three operating
+modes (pipetting, splitting, dilution) — no hardware modifications needed.
 
-These pipettes use a Silicon Labs **CP2102** USB-UART bridge (VID `0x10C4`,
-PID `0xEA60`) to communicate at 9600 baud 8N1.  This project provides an
-open-source Python driver for programmatic pipette control on Linux and macOS.
+Uses the Silicon Labs **CP2102** USB-UART bridge (VID `0x10C4`, PID `0xEA60`)
+at 9600 baud 8N1.
 
 ## Why this matters
 
 There is **no open-source, disposable-tip, API-controlled pipette** at
-this price point.  Every cheap open-source liquid handler ($100–300) uses
-syringe pumps — fine for non-contaminating reagents, but unusable for
-biological work due to carryover between samples.  The dPette uses
-standard disposable tips, putting it in a different class for actual lab
-use.
+this price point.
 
 | Solution | Cost | Tips | API control |
 |----------|------|------|-------------|
-| **dPette + MOSFET (this project)** | **~$140** | **Disposable** | **Full serial** |
+| **dPette + this driver** | **~$130** | **Disposable** | **Full serial** |
 | ac-rad Digital Pipette v2 | ~$200 | Syringe (no tips) | Arduino |
 | Science Jubilee + OT-2 pipette | ~$900+ | Disposable | Python |
 | Opentrons OT-2 | ~$10,000+ | Disposable | Python |
 | Hamilton STAR | ~$100,000+ | Disposable | VENUS/Python |
 
-The [ac-rad Digital Pipette v2](https://github.com/ac-rad/digital-pipette-v2)
-paper explicitly identifies disposable-tip handling as an **unsolved open
-hardware problem** for self-driving labs.  This project solves it for $140.
+## What works
 
-### Integration opportunity
-
-[PyLabRobot](https://github.com/PyLabRobot/pylabrobot) is a hardware-agnostic
-Python SDK for liquid handling (used by pharma and academic self-driving labs).
-The dpette driver (56 tests, full protocol) could be contributed as a new
-backend, making the $140 dPette a first-class citizen in an ecosystem
-alongside Hamilton and Opentrons robots.
-
-## What works today (v0.1.0)
-
-- **Aspirate** at the physical dial volume (B0 prime → B3 aspirate)
-- **Dispense** (B0 command)
-- **EEPROM read/write** of calibration coefficients
-- **Volume control** via A6 + physical button press in calibration mode
-- Full 6-byte protocol decoded (48 experiments, PetteCali serial capture)
-- 56 tests passing, complete documentation
-
-## Architecture
-
-```
-┌────────────┐   USB    ┌────────┐   UART    ┌─────┐   motor   ┌────────┐
-│  Host PC   │ ──────── │ CP2102 │ ──────── │ MCU │ ────────── │ Piston │
-│ (this code)│          │ bridge │          │     │            │        │
-└────────────┘          └────────┘          └─────┘            └────────┘
-```
-
-### With button MOSFET (roadmap):
-
-```
-┌────────────┐   USB    ┌────────┐   UART    ┌─────┐   motor   ┌────────┐
-│  Host PC   │ ──────── │ CP2102 │ ──────── │ MCU │ ────────── │ Piston │
-│ (this code)│          │ bridge │          │     │            │        │
-└──────┬─────┘          └────────┘          └──┬──┘            └────────┘
-       │ GPIO                                  │
-       ▼                                       │
-  ┌─────────┐   BSS138    ┌────────┐           │
-  │ RP2040  │ ──────────▶ │ Button │ ──────────┘
-  │         │   MOSFET    │contacts│  (simulates button press)
-  └─────────┘             └────────┘
-```
-
-## Confirmed automation cycle (EXP-048)
-
-With a BSS138 MOSFET wired across the pipette's button contacts:
-
-```
-Enter cal mode (once) →
-  A6 set volume (serial)  →  button press (MOSFET)  →  B0 dispense (serial)
-  A6 new volume (serial)  →  button press (MOSFET)  →  B0 dispense (serial)
-  ... repeat at any volume
-```
-
-Tested at 30, 100, and 300 µL — volumes match A6 setting exactly.
-
-## Roadmap
-
-### v0.1.0 — Protocol & fixed-volume pipetting ✅
-- [x] 6-byte protocol fully decoded
-- [x] Handshake, aspirate (B3), dispense (B0)
-- [x] EEPROM read/write (A3/A4)
-- [x] PetteCali serial capture analysis
-- [x] 48 experiments documented
-
-### v0.2.0 — Button press hardware (current)
-- [ ] BSS138 MOSFET wired across button contacts
-- [ ] RP2040 or Arduino GPIO to drive MOSFET
-- [ ] `driver.trigger_button()` method via GPIO
-- [ ] Full A6 → MOSFET → B0 automation cycle
-- [ ] Test on fresh dPette (avoid Err4 from serial A5 b2=1)
-
-### v0.3.0 — Calibration & error handling
-- [ ] Proper recalibration via PetteCali (fix dummy k/b values)
-- [ ] Err4 investigation via debug port (open device, identify MCU)
-- [ ] Err4 prevention (enter cal mode via MOSFET, not serial A5 b2=1)
-- [ ] Automated error recovery
-
-### v0.4.0 — Lab integration
-- [ ] Multi-pipette support (multiple serial ports)
-- [ ] Protocol automation scripts (serial dilutions, plate filling)
-- [ ] Integration with lab automation frameworks (OpenTrons, PyLabRobot)
-- [ ] Volume accuracy validation with gravimetric testing
-
-## Safety & warranty disclaimer
-
-> **WARNING:** This software is provided as-is for research and educational
-> purposes.  Using it may void your pipette's warranty.  The authors are not
-> responsible for damage to hardware, incorrect pipetting results, or any
-> downstream consequences.
->
-> **DANGEROUS COMMANDS:** Sending `FE A5 01` (enter calibration mode) via
-> serial causes persistent Err4 that survives reboots.  See
-> `docs/PROTOCOL_NOTES.md` for details.  The driver does not send this
-> command — use the MOSFET button press to enter cal mode instead.
->
-> The driver enforces software safety limits (see `docs/SAFETY_MODEL.md`),
-> but these cannot protect against all failure modes.  Never use this
-> software for clinical or safety-critical applications without independent
-> validation.
-
-## Installation
-
-```bash
-# From source (recommended during alpha)
-git clone https://github.com/Lambda-Biolab/dpette-usb-driver.git
-cd dpette-usb-driver
-uv pip install -e .
-
-# Or install directly from GitHub
-uv pip install git+https://github.com/Lambda-Biolab/dpette-usb-driver.git
-```
+- **Volume-controlled aspirate/dispense** — set any volume via serial (B2), confirmed in EXP-050
+- **Three operating modes** — PI (pipetting), ST (splitting), DI (dilution)
+- **Speed control** — 3 speed levels for aspirate and dispense
+- **Mixing** — aspirate/dispense cycling with caller-controlled tip position
+- **EEPROM read/write** — firmware version, calibration coefficients
+- 94 tests passing, 55 experiments documented
 
 ## Quickstart
 
-### 1. Connect the pipette
-
-Plug the dPette into your computer via USB.  It should appear as:
-- **macOS:** `/dev/cu.usbserial-0001`
-- **Linux:** `/dev/ttyUSB0`
-
-If the pipette shows Err4 on the display, hold the operation button
-to dismiss it.
-
-### 2. Basic aspirate/dispense (at dial volume)
-
-```python
-from dpette.config import SerialConfig
-from dpette.driver import DPetteDriver
-
-cfg = SerialConfig(port="/dev/cu.usbserial-0001")  # adjust for your OS
-driver = DPetteDriver(cfg)
-
-driver.connect()       # handshake + prime
-driver.aspirate()      # aspirates at the physical dial volume
-driver.dispense()      # dispenses
-driver.disconnect()
+```bash
+git clone https://github.com/Lambda-Biolab/dpette-usb-driver.git
+cd dpette-usb-driver
+uv pip install -e .
 ```
 
-### 3. Volume-controlled pipetting (requires button MOSFET)
+### Aspirate and dispense
 
 ```python
-from dpette.protocol import Command, encode_packet, send_cali_volume_packet
-from dpette.serial_link import SerialLink
-from dpette.config import SerialConfig
+from dpette import DPetteDriver, SerialConfig
 
-link = SerialLink(SerialConfig(port="/dev/cu.usbserial-0001"))
-link.open()
+drv = DPetteDriver(SerialConfig(port="/dev/cu.usbserial-0001"))
+drv.connect()           # A0 handshake + enter PI mode
 
-# Handshake
-link.write(encode_packet(Command.HANDSHAKE))
-link.read(6)
+drv.aspirate(200.0)     # sets volume to 200 µL, aspirates
+drv.dispense()          # dispenses
 
-# Enter cal mode (via MOSFET button press — NOT serial A5 b2=1)
-trigger_button()  # your MOSFET GPIO function
+drv.aspirate(50.0)      # change volume on the fly
+drv.dispense()
 
-# Set volume and aspirate
-link.write(send_cali_volume_packet(200))  # 200 µL
-link.read(6)
-trigger_button()  # aspirates 200 µL
-
-# Dispense via serial
-link.write(encode_packet(Command.DISPENSE, b2=0x01))
-link.read(6)
-
-# Change volume and repeat
-link.write(send_cali_volume_packet(50))   # 50 µL
-link.read(6)
-trigger_button()  # aspirates 50 µL
+drv.disconnect()
 ```
 
-See `examples/` for complete working scripts.
-
-### 4. Read EEPROM data
+### Mixing
 
 ```python
-from dpette.protocol import read_ee_packet, encode_packet, Command
-from dpette.serial_link import SerialLink
-from dpette.config import SerialConfig
-
-link = SerialLink(SerialConfig(port="/dev/cu.usbserial-0001"))
-link.open()
-link.write(encode_packet(Command.HANDSHAKE))
-link.read(6)
-
-# Read firmware version (addresses 0x60-0x67)
-for addr in range(0x60, 0x68):
-    link.write(read_ee_packet(addr))
-    resp = link.read(6)
-    print(chr(resp[2]), end="")  # prints "Ver4.2.3"
+# Tip must be raised above liquid before dispense
+# (blow includes piston return that creates suction)
+for _ in range(5):
+    # lower tip into liquid
+    drv.mix_aspirate(100.0, speed=3)
+    # raise tip above liquid
+    drv.mix_dispense()
 ```
 
-### 5. Run tests (no hardware needed)
+### Splitting (aliquots)
+
+```python
+from dpette.protocol import WorkingMode
+
+drv.split_setup(100.0, count=3)   # enters ST mode, sets 100 µL × 3
+
+# tip in liquid
+drv.split_aspirate()               # aspirates total (300 µL)
+
+# raise tip, move to destination wells
+drv.split_dispense()               # aliquot 1
+drv.split_dispense()               # aliquot 2
+drv.split_dispense()               # aliquot 3
+```
+
+### Dilution
+
+```python
+drv.dilute_setup(200.0, 100.0)    # enters DI mode
+
+# tip in diluent
+drv.dilute_aspirate()              # aspirates 200 µL
+
+# tip in sample
+drv.dilute_aspirate()              # aspirates 100 µL on top
+
+# raise tip — switch to PI mode to dispense (DI blow
+# doesn't trigger motor on basic dPette)
+drv.enter_mode(WorkingMode.PI)     # homes motor, expels liquid
+```
+
+### Speed control
+
+```python
+from dpette.protocol import KeyAction
+
+drv.set_speed(KeyAction.SUCK, 3)  # fast aspirate
+drv.set_speed(KeyAction.BLOW, 1)  # slow dispense
+```
+
+### Run tests (no hardware needed)
 
 ```bash
-make test    # or: pytest
-make lint    # or: ruff check src/ tests/ && mypy src/
+pytest                  # 94 tests
+ruff check src/ tests/  # lint
+mypy src/               # type check
 ```
 
-## Development
+## Protocol
 
-```bash
-make lint    # ruff + mypy
-make test    # pytest
-make all     # both
-```
-
-## Project structure
+All communication uses 6-byte packets:
 
 ```
-src/dpette/
-  config.py        — serial port configuration and discovery
-  serial_link.py   — thin pyserial wrapper (raw I/O only)
-  protocol.py      — frame encoding / decoding (confirmed from 48 experiments)
-  safety.py        — parameter validation and mechanical limits
-  driver.py        — high-level pipetting API
-  logging_utils.py — centralised logging
-
-tools/             — 40+ exploratory scripts from RE session
-tests/             — pytest suite (56 tests, works without hardware)
-docs/
-  PROTOCOL_NOTES.md  — full protocol specification
-  EXPERIMENT_LOG.md  — 48 experiments with results and dead ends
-  HARDWARE.md        — CP2102 details, device identification
-  SAFETY_MODEL.md    — mechanical risks and software guardrails
+[0xFE] [CMD] [B2] [B3] [B4] [CHECKSUM]   host → device
+[0xFD] [CMD] [B2] [B3] [B4] [CHECKSUM]   device → host
 ```
 
-## Key documentation
+Checksum = `sum(bytes[1:5]) & 0xFF`.
 
-- [Protocol Notes](docs/PROTOCOL_NOTES.md) — complete packet format, command reference
-- [Experiment Log](docs/EXPERIMENT_LOG.md) — 48 experiments, chronological
-- [Hardware Notes](docs/HARDWARE.md) — CP2102, MCU, device connection
-- [Safety Model](docs/SAFETY_MODEL.md) — risks, limits, dangerous commands
+| CMD | Name | Function |
+|-----|------|----------|
+| A0 | HELLO | Handshake |
+| A3 | EE_READ | Read EEPROM byte |
+| A4 | EE_WRITE | Write EEPROM byte |
+| A5 | DEMARCATE | Enter/exit calibration mode (**causes Err4**) |
+| A7 | RESET | Factory reset (calibration only, not Err4) |
+| B0 | WOL | Enter mode: PI=1, ST=2, DI=3 (homes motor) |
+| B1 | SPEED | Set speed: direction (1=suck, 2=blow), level (1-3) |
+| B2 | PI_VOLUM | Set volume: µL × 100, 24-bit big-endian |
+| B3 | KEY | Aspirate (b2=1) or dispense (b2=2), double response |
+| B4 | ST_VOLUM | Split volume per aliquot (× 100, 24-bit) |
+| B5 | ST_NUM | Number of splits |
+| B6/B7 | DI1/DI2_VOLUM | Dilution volumes 1 and 2 (× 100, 24-bit) |
+
+See [docs/PROTOCOL_NOTES.md](docs/PROTOCOL_NOTES.md) for the full specification.
+
+## Known issues
+
+- **Err4 on startup**: Caused by `A5 b2=1` (calibration mode entry via
+  serial). Persists across reboots. Cannot be cleared via serial — only
+  PetteCali (Windows) fixes it. Dismiss by holding the button. All serial
+  operations work normally after dismissal.
+- **DI mode dispense**: B3 blow doesn't trigger motor on basic dPette.
+  Workaround: `enter_mode(WorkingMode.PI)` homes the motor and expels liquid.
+- **Piston return suction**: B3 blow includes a piston return to home.
+  If the tip is submerged, this draws extra liquid. Always dispense with
+  tip above liquid.
+
+## Safety
+
+> **WARNING:** This software is provided as-is for research and educational
+> purposes. Using it may void your pipette's warranty.
+>
+> **Do NOT send `FE A5 01`** (enter calibration mode) — causes persistent
+> Err4. The driver never sends this command.
+
+## Documentation
+
+- [Protocol Notes](docs/PROTOCOL_NOTES.md) — full command reference
+- [Experiment Log](docs/EXPERIMENT_LOG.md) — 55 experiments with results
+- [Hardware Notes](docs/HARDWARE.md) — CP2102, device connection
+- [Safety Model](docs/SAFETY_MODEL.md) — risks and software guardrails
 
 ## License
 

--- a/examples/basic_pipette.py
+++ b/examples/basic_pipette.py
@@ -1,14 +1,5 @@
 #!/usr/bin/env python3
-"""Basic pipette control — aspirate and dispense at the dial volume.
-
-This is the simplest working example. No calibration mode, no volume
-control — just aspirate and dispense at whatever volume the physical
-dial is set to.
-
-Prerequisites:
-    - dPette connected via USB
-    - Dismiss Err4 if showing (hold the pipette button)
-    - Tip attached
+"""Basic pipette control — aspirate and dispense at a set volume.
 
 Usage:
     python examples/basic_pipette.py
@@ -19,30 +10,22 @@ from dpette.driver import DPetteDriver
 
 
 def main() -> None:
-    # Auto-detect the serial port, or specify manually
-    port = guess_default_port()
-    if port is None:
-        port = "/dev/cu.usbserial-0001"  # macOS default
-        # port = "/dev/ttyUSB0"           # Linux default
+    port = guess_default_port() or "/dev/cu.usbserial-0001"
 
     print(f"Connecting to dPette on {port}...")
     cfg = SerialConfig(port=port)
     driver = DPetteDriver(cfg)
 
     driver.connect()
-    print("Connected! (handshake + prime complete)")
+    print("Connected!")
 
-    # Aspirate at dial volume
-    print("Aspirating...")
-    resp = driver.aspirate()
-    print(f"  Aspirate response: {resp.raw.hex(' ')}")
+    print("Aspirating 200 µL...")
+    driver.aspirate(200.0)
 
     input("Press Enter to dispense...")
 
-    # Dispense
     print("Dispensing...")
-    resp = driver.dispense()
-    print(f"  Dispense response: {resp.raw.hex(' ')}")
+    driver.dispense()
 
     driver.disconnect()
     print("Done.")

--- a/examples/read_eeprom.py
+++ b/examples/read_eeprom.py
@@ -24,7 +24,7 @@ def main() -> None:
     link.open()
 
     # Handshake
-    link.write(encode_packet(Command.HANDSHAKE))
+    link.write(encode_packet(Command.HELLO))
     time.sleep(1.0)
     resp = link.read(6)
     print(f"Handshake: {resp.hex(' ')}")
@@ -51,14 +51,14 @@ def main() -> None:
     for seg, bk, bb in [(1, 0x90, 0x94), (2, 0x98, 0x9C)]:
         k = read_u32(bk)
         b = read_u32(bb)
-        print(f"  Segment {seg}: k={k/10000:.4f}  b={b/10000:.4f}")
+        print(f"  Segment {seg}: k={k / 10000:.4f}  b={b / 10000:.4f}")
 
     print()
     print("Factory defaults:")
     for seg, bk, bb in [(1, 0xA0, 0xA4), (2, 0xA8, 0xAC)]:
         k = read_u32(bk)
         b = read_u32(bb)
-        print(f"  Segment {seg}: k={k/10000:.4f}  b={b/10000:.4f}")
+        print(f"  Segment {seg}: k={k / 10000:.4f}  b={b / 10000:.4f}")
 
     # Volume range
     print()

--- a/examples/volume_control.py
+++ b/examples/volume_control.py
@@ -1,76 +1,36 @@
 #!/usr/bin/env python3
-"""Volume-controlled pipetting via calibration mode.
+"""Volume-controlled pipetting — set volume via serial, no hardware mods.
 
-This example sets the aspiration volume remotely using A6, then
-triggers aspiration with the physical button (or MOSFET actuator).
-
-**Requires:** A way to press the pipette's physical button — either
-manually or via a BSS138 MOSFET wired across the button contacts.
-See GitHub issue #3 for the MOSFET wiring guide.
-
-WARNING: Entering calibration mode via serial (A5 b2=1) causes
-persistent Err4 on reboot. On a fresh device, use the MOSFET to
-press the button instead of sending A5 b2=1 via serial.
+Demonstrates changing the aspiration volume between cycles using B2
+(PI_VOLUM). The volume is controlled entirely via serial commands.
 
 Usage:
     python examples/volume_control.py
 """
 
-import time
-
 from dpette.config import SerialConfig, guess_default_port
-from dpette.protocol import (
-    Command,
-    encode_packet,
-    send_cali_volume_packet,
-)
-from dpette.serial_link import SerialLink
+from dpette.driver import DPetteDriver
 
 
 def main() -> None:
     port = guess_default_port() or "/dev/cu.usbserial-0001"
     cfg = SerialConfig(port=port)
-    link = SerialLink(cfg)
+    driver = DPetteDriver(cfg)
 
     print(f"Connecting to dPette on {port}...")
-    link.open()
+    driver.connect()
 
-    # Handshake
-    link.write(encode_packet(Command.HANDSHAKE))
-    resp = link.read(6)
-    print(f"Handshake: {resp.hex(' ')}")
-
-    # Enter calibration mode
-    # WARNING: causes persistent Err4 on reboot!
-    # On a fresh device, use MOSFET button press instead.
-    print("Entering calibration mode...")
-    link.write(encode_packet(Command.HANDSHAKE, b2=0x01))
-    time.sleep(3.0)
-    resp = link.read(6)
-    print(f"Enter cal: {resp.hex(' ') if resp else '(no response — dismiss Err4)'}")
-
-    input("Dismiss Err4 if showing, wait for homing. Press Enter...")
-    time.sleep(3.0)
-
-    # Set volume and aspirate
-    volumes = [100, 200, 300]
+    volumes = [50, 100, 200]
     for vol in volumes:
-        print(f"\n--- Setting volume to {vol} µL ---")
-        link.write(send_cali_volume_packet(vol))
-        time.sleep(0.5)
-        resp = link.read(6)
-        print(f"A6={vol}: {resp.hex(' ') if resp else '(none)'}")
+        input(f"\nPress Enter to aspirate {vol} µL...")
+        driver.aspirate(float(vol))
+        print(f"Aspirated {vol} µL.")
 
-        input(f"Press the PHYSICAL BUTTON to aspirate {vol} µL, then Enter...")
+        input("Press Enter to dispense...")
+        driver.dispense()
+        print("Dispensed.")
 
-        # Dispense via serial
-        print("Dispensing via B0...")
-        link.write(encode_packet(Command.DISPENSE, b2=0x01))
-        time.sleep(2.0)
-        resp = link.read(6)
-        print(f"Dispense: {resp.hex(' ') if resp else '(none)'}")
-
-    link.close()
+    driver.disconnect()
     print("\nDone.")
 
 


### PR DESCRIPTION
## Summary

- Rewrite README: remove MOSFET references, document PI/ST/DI modes, volume/speed control, mixing API
- Fix broken examples: `read_eeprom.py` and `volume_control.py` used deleted `Command.HANDSHAKE`/`Command.DISPENSE` constants
- Update `basic_pipette.py` to use volume parameter
- Cost updated from ~$140 (with MOSFET) to ~$130 (pipette + USB only)
- Counts updated: 94 tests, 55 experiments

## Test plan

- [x] 94 tests passing
- [x] All examples use valid Command constants

🤖 Generated with [Claude Code](https://claude.com/claude-code)