### PR TITLE
chore: de-vibe governance (AGENTS.md, CI, .claude/, licensing)

### DIFF
--- a/.claude/rules/serial-protocol.md
+++ b/.claude/rules/serial-protocol.md
@@ -1,0 +1,17 @@
+# Serial Protocol Safety
+
+## Packet format
+All packets are exactly 6 bytes: `[0xFE] [CMD] [B2] [B3] [B4] [CHECKSUM]`
+
+## Critical constraints
+- **NEVER send `A5 b2=1`** (calibration mode entry) — causes persistent Err4
+  that survives reboots and cannot be cleared via serial
+- Only send packets produced by `protocol.encode_packet()`; raw hand-crafted
+  bytes are reserved for `tools/` scripts
+- Volume and speed parameters MUST pass through `safety.validate_volume()` and
+  `safety.validate_speed()` before transmission
+
+## EEPROM writes
+Writing incorrect calibration values (k/b coefficients) via `A4` can break
+motor control. `write_ee()` is provisional — do not use without understanding
+the exact byte layout.

--- a/.claude/rules/tools-hygiene.md
+++ b/.claude/rules/tools-hygiene.md
@@ -1,0 +1,6 @@
+# Tools Hygiene
+
+- Experiment scripts go in `tools/`, one-off probing scripts in `tools/archive/`
+- All hardware interaction scripts MUST log to `captures/`
+- Follow the experiment process documented in `docs/EXPERIMENT_LOG.md`
+- Never commit raw capture data (`.bin`, `.log` > 100KB) — reference by path only

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,44 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(git tag:*)",
+      "Bash(make:*)",
+      "Bash(uv sync:*)",
+      "Bash(uv run:*)",
+      "Bash(ls:*)",
+      "Bash(pwd:*)",
+      "Bash(wc:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh pr:*)"
+    ],
+    "deny": [
+      "Bash(rm -rf /)",
+      "Bash(git push --force:*)",
+      "Bash(git reset --hard:*)"
+    ]
+  },
+  "enabledPlugins": {
+    "context7@claude-plugins-official": true,
+    "tdd-core@qte77-claude-code-utils": true,
+    "python-dev@qte77-claude-code-utils": true,
+    "commit-helper@qte77-claude-code-utils": true,
+    "simplify@qte77-claude-code-utils": true,
+    "docs-governance@qte77-claude-code-utils": true,
+    "makefile-core@qte77-claude-code-utils": true,
+    "cc-meta@qte77-claude-code-utils": true,
+    "workspace-setup@qte77-claude-code-utils": true
+  },
+  "extraKnownMarketplaces": {
+    "qte77-claude-code-utils": {
+      "source": {
+        "source": "github",
+        "repo": "qte77/claude-code-utils-plugin"
+      }
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --extra dev
 
       - name: Check formatting
         run: uv run ruff format --check src/ tests/ tools/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Check formatting
+        run: uv run ruff format --check src/ tests/ tools/
+
+      - name: Lint
+        run: uv run ruff check src/ tests/ tools/
+
+      - name: Type check
+        run: uv run mypy src/
+
+      - name: Test
+        run: uv run pytest -v -m "not hardware"

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,51 @@
+name: Links
+
+on:
+  push:
+    branches-ignore: [main]
+  pull_request:
+    types: [closed]
+    branches: [main]
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lychee link check
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: "--config .lychee.toml ."
+          fail: true
+
+      - name: Create issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = "Broken links detected";
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: "broken-links",
+            });
+            if (issues.length === 0) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body: "The [link checker](" + context.serverUrl + "/" + context.repo.owner + "/" + context.repo.repo + "/actions/runs/" + context.runId + ") found broken links. Please review the workflow logs.",
+                labels: ["broken-links"],
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ captures/static-analysis/ghidra-project/
 # Temp logs from live probing
 captures/*.txt
 
+# Vendor documents
+captures/static-analysis/pettecali_instructions.pdf
+
 # OS
 .DS_Store
 Thumbs.db

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,5 +1,5 @@
 # Lychee link checker config
-accept = [200, 201, 204, 429]
+accept = [200, 201, 202, 204, 429]
 timeout = 30
 max_retries = 2
 
@@ -8,4 +8,5 @@ exclude = [
     "^https://github\\.com/Lambda-Biolab/",
     "^https://hub\\.docker\\.com",
     "^https://pypi\\.org",
+    "^https://www\\.dlab\\.com\\.cn",
 ]

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,11 @@
+# Lychee link checker config
+accept = [200, 201, 204, 429]
+timeout = 30
+max_retries = 2
+
+exclude = [
+    "^https://img\\.shields\\.io",
+    "^https://github\\.com/Lambda-Biolab/",
+    "^https://hub\\.docker\\.com",
+    "^https://pypi\\.org",
+]

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD024": { "siblings_only": true },
+  "MD033": false,
+  "MD041": false
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# AGENTS.md — dpette-usb-driver
+
+Reverse-engineered Python driver for **DLAB dPette / dPette+** electronic
+pipettes. Provides full serial volume control over USB-UART (CP2102) at
+9600 baud 8N1. No hardware modifications required for basic operation.
+
+## Architecture
+
+```
+src/dpette/
+  driver.py        — High-level API (connect, aspirate, dispense, mix, split, dilute)
+  protocol.py      — 6-byte packet encode/decode, command enums, working modes
+  serial_link.py   — Thin pyserial wrapper (read/write/flush)
+  safety.py        — Volume/speed validation, cycle-count limits
+  config.py        — SerialConfig dataclass, port discovery
+  logging_utils.py — Structured logging helpers
+```
+
+## Domain Rules
+
+### Protocol invariants
+- All packets are exactly 6 bytes: `[0xFE] [CMD] [B2] [B3] [B4] [CHECKSUM]`
+- Checksum = `sum(bytes[1:5]) & 0xFF`
+- Volumes are encoded as micro-litres x 100 in 24-bit big-endian
+- B3 (KEY) commands produce a **double response** — always read both
+
+### Safety-critical constraints
+- **NEVER send `A5 b2=1`** (calibration mode entry) — causes persistent
+  Err4 that survives reboots and cannot be cleared via serial
+- `driver.py` must only send packets produced by `protocol.encode_packet()`;
+  raw hand-crafted bytes are reserved for `tools/` scripts
+- Volume and speed parameters pass through `safety.validate_volume()` and
+  `safety.validate_speed()` before transmission
+- Cycle counter (`MAX_CONTIGUOUS_CYCLES = 50`) prevents unattended runaway
+
+### DI mode workaround
+B3 blow does not trigger the motor on basic dPette in dilution mode.
+Workaround: call `enter_mode(WorkingMode.PI)` which homes the motor and
+expels liquid.
+
+### Piston return suction
+B3 blow includes a piston return to home position. If the tip is submerged,
+this draws extra liquid. Always dispense with tip above liquid surface.
+
+### EEPROM writes
+Writing incorrect calibration values (k/b coefficients) via `A4` can break
+motor control. `write_ee()` is provisional — do not use without understanding
+the exact byte layout.
+
+## Testing
+
+All tests use **mock serial ports** (pytest-mock). No physical hardware
+required for the default test suite.
+
+```bash
+make test              # pytest (hardware tests excluded)
+make validate          # full read-only gate (format + lint + mypy + tests)
+make quick_validate    # fast gate (lint + mypy, no tests)
+make lint_fix          # auto-fix formatting and lint issues
+make check_complexity  # complexipy analysis
+make check_links       # lychee link checker
+make check_docs        # markdownlint
+```
+
+Tests requiring a physical device use `@pytest.mark.hardware` and run with:
+```bash
+pytest -m hardware
+```
+
+## Experiments
+
+Hardware probing follows a structured process documented in
+`docs/EXPERIMENT_LOG.md`. New experiments go in `tools/` with logging to
+`captures/`. Archive one-off scripts to `tools/archive/`.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| [README.md](README.md) | Project overview, quickstart, protocol summary |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Dev setup, code structure, experiment workflow |
+| [AGENT_LEARNINGS.md](AGENT_LEARNINGS.md) | Gotchas and lessons learned |
+| [docs/PROTOCOL_NOTES.md](docs/PROTOCOL_NOTES.md) | Full command reference |
+| [docs/SAFETY_MODEL.md](docs/SAFETY_MODEL.md) | Risk analysis and software guardrails |
+| [docs/EXPERIMENT_LOG.md](docs/EXPERIMENT_LOG.md) | 55 hardware experiments with results |
+| [docs/HARDWARE.md](docs/HARDWARE.md) | CP2102 connection details |

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -1,0 +1,52 @@
+# Agent Learnings
+
+Recurring patterns, gotchas, and solutions discovered during development.
+
+## Format
+
+Each entry follows: **Context** / **Problem** / **Solution**
+
+---
+
+### 1. A5 calibration mode causes persistent Err4
+
+- **Context:** Sending command `A5` with `b2=1` to enter calibration mode
+- **Problem:** Sets a persistent flag in the pipette firmware that causes
+  Err4 on every subsequent power-on. Cannot be cleared via serial commands.
+  Confirmed on two separate devices.
+- **Solution:** Never send `A5 b2=1`. The driver uses only `A5 b2=0` for
+  handshake. Clearing Err4 requires PetteCali (Windows software) with a
+  full calibration cycle.
+
+### 2. B3 KEY produces double response
+
+- **Context:** Sending B3 (aspirate/dispense) commands
+- **Problem:** The device sends two response packets for every B3 command.
+  Reading only one response desynchronizes the serial buffer, causing
+  subsequent reads to return stale data.
+- **Solution:** Always read two responses after B3. See
+  `protocol.py` and `driver.py` implementation.
+
+### 3. DI mode blow does not trigger motor on basic dPette
+
+- **Context:** Using dilution (DI) mode on the basic dPette (not dPette+)
+- **Problem:** B3 blow command in DI mode does not drive the motor, so
+  liquid is not expelled.
+- **Solution:** Switch to PI mode with `enter_mode(WorkingMode.PI)` which
+  homes the motor and expels all liquid. Document this as a known limitation.
+
+### 4. Piston return creates suction after dispense
+
+- **Context:** Dispensing liquid with tip submerged in liquid
+- **Problem:** B3 blow includes a piston return to home position. If the
+  tip is still in liquid, the return stroke draws extra liquid into the tip.
+- **Solution:** Always raise the tip above the liquid surface before
+  dispensing. This is a mechanical constraint, not a software bug.
+
+### 5. EEPROM k/b coefficient writes can break motor control
+
+- **Context:** Writing calibration coefficients to EEPROM via A4 command
+- **Problem:** Incorrect values cause the motor to refuse aspirate/dispense
+  commands with no error response — it simply does nothing.
+- **Solution:** `write_ee()` is provisional. Do not write EEPROM values
+  without understanding the exact byte layout from PetteCali captures.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Redirected to [AGENTS.md](AGENTS.md) for project documentation
+
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: init lint test all clean
+.PHONY: init lint lint_fix test validate quick_validate check_complexity check_links check_docs all clean
 
 init:
 	pip install -e ".[dev]"
@@ -8,8 +8,31 @@ lint:
 	ruff check src/ tests/ tools/
 	mypy src/
 
+lint_fix:
+	ruff format src/ tests/ tools/
+	ruff check --fix src/ tests/ tools/
+
 test:
 	pytest -v
+
+validate:
+	ruff format --check src/ tests/ tools/
+	ruff check src/ tests/ tools/
+	mypy src/
+	pytest -v -m "not hardware"
+
+quick_validate:
+	ruff check src/ tests/ tools/
+	mypy src/
+
+check_complexity:
+	complexipy src/dpette/ --max-complexity-allowed 15
+
+check_links:
+	lychee --config .lychee.toml .
+
+check_docs:
+	markdownlint-cli2 "**/*.md" "#node_modules"
 
 all: lint test
 

--- a/docs/LICENSING_ASSESSMENT.md
+++ b/docs/LICENSING_ASSESSMENT.md
@@ -1,0 +1,50 @@
+# Licensing Assessment — dpette-usb-driver
+
+Assessment of IP and licensing considerations for making this repository public.
+
+## Verdict: LOW RISK — safe to publish with minor cleanup
+
+The Python driver is original code communicating over a standard USB-UART
+serial interface. No vendor code or binaries are committed.
+
+## Legal Basis
+
+Reverse engineering of communication protocols for interoperability is
+protected under:
+
+- **US:** DMCA §1201(f) interoperability exception
+  — https://www.law.cornell.edu/uscode/text/17/1201
+- **EU:** Software Directive 2009/24/EC, Article 6
+  — https://eur-lex.europa.eu/eli/dir/2009/24/oj
+
+No DRM, encryption, or access controls are circumvented. The driver observes
+and speaks a plaintext serial protocol over standard UART hardware.
+
+## Items to Address Before Public Release
+
+1. **Remove `captures/static-analysis/pettecali_instructions.pdf`** — vendor
+   document, potential copyright issue. Verify it is publicly distributed by
+   DLAB before including.
+
+2. **Review `docs/PROTOCOL_NOTES.md`** — currently references Ghidra
+   disassembly addresses (e.g., `FUN_140069730`). Consider describing observed
+   behavior instead of citing decompilation artifacts. Not legally required,
+   but reduces exposure.
+
+3. **Add interoperability disclaimer to README:**
+   > Not affiliated with DLAB Scientific. Protocol information was determined
+   > through interoperability analysis of serial communication.
+
+## What Is Already Clean
+
+- `.gitignore` excludes `PetteCali.exe`, decompiled `.c` files, and extracted
+  binaries — no vendor code is committed
+- All Python code is original (not derived from decompilation)
+- No EULA, NDA, or patent restrictions found for DLAB pipette instruments
+- DLAB does not publish a public API or SDK, strengthening the
+  interoperability justification
+
+## References
+
+- DLAB Scientific (vendor): https://www.dlab.com.cn
+- xg590/Learn_dPettePlus (prior art, third-party RE): referenced in README

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
     "mypy>=1.10,<2",
     "types-pyserial>=3.5",
     "pre-commit>=3.7,<4",
+    "complexipy>=0.8",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -45,7 +46,10 @@ target-version = "py311"
 src = ["src"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "N", "UP", "B", "A", "SIM", "TCH"]
+select = ["E", "F", "W", "I", "N", "UP", "B", "A", "SIM", "TCH", "C90"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
 "tools/*" = ["E501", "B007", "SIM115"]
@@ -88,3 +92,7 @@ ignore_errors = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "-m \"not hardware\""
+markers = [
+    "hardware: requires physical dPette device",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
 "tools/*" = ["E501", "B007", "SIM115"]
+"tools/archive/*" = ["E501", "B007", "SIM115", "C901"]
 "examples/*" = ["E501"]
 
 [tool.mypy]

--- a/src/dpette/driver.py
+++ b/src/dpette/driver.py
@@ -144,8 +144,7 @@ class DPetteDriver:
         raw = self._link.read(PACKET_LEN)
         if len(raw) < PACKET_LEN:
             raise TimeoutError(
-                f"Device did not respond within {timeout:.1f}s "
-                f"(got {len(raw)} bytes)"
+                f"Device did not respond within {timeout:.1f}s (got {len(raw)} bytes)"
             )
         return decode_packet(raw)
 

--- a/tools/archive/find_dispense.py
+++ b/tools/archive/find_dispense.py
@@ -58,7 +58,7 @@ candidates = [
 
 for i, (label, cmd, b2) in enumerate(candidates):
     print(f"\n{'=' * 50}")
-    print(f"[{i+1}/{len(candidates)}] >>> {label}")
+    print(f"[{i + 1}/{len(candidates)}] >>> {label}")
     print("    WATCH FOR DISPENSE (piston pushes down)")
     print(f"{'=' * 50}")
     time.sleep(3.0)

--- a/tools/archive/interactive_post_aspirate.py
+++ b/tools/archive/interactive_post_aspirate.py
@@ -51,9 +51,9 @@ def read_state(label: str) -> None:
         resp = send_recv(ser, make_pkt(cmd, 0x00), wait=0.3)
         b2_val = resp[2] if len(resp) > 2 else -1
         print(
-            f"    B{cmd-0xB0} status: b2=0x{b2_val:02X}"
+            f"    B{cmd - 0xB0} status: b2=0x{b2_val:02X}"
             if b2_val >= 0
-            else f"    B{cmd-0xB0}: (none)"
+            else f"    B{cmd - 0xB0}: (none)"
         )
     print()
 
@@ -71,7 +71,7 @@ steps = [
 ]
 
 for i, (label, action) in enumerate(steps):
-    print(f"=== Step {i+1}/{len(steps)}: {label} ===")
+    print(f"=== Step {i + 1}/{len(steps)}: {label} ===")
 
     if action == "aspirate":
         input("Press ENTER to aspirate: ")

--- a/tools/archive/interactive_vol_increment.py
+++ b/tools/archive/interactive_vol_increment.py
@@ -61,7 +61,7 @@ candidates = [
 ]
 
 for i, (label, cmd, b2) in enumerate(candidates):
-    print(f"--- [{i+1}/{len(candidates)}] {label} ---")
+    print(f"--- [{i + 1}/{len(candidates)}] {label} ---")
     ans = input("Press ENTER to send 3× (or 'q' to quit): ")
     if ans.strip().lower() == "q":
         break
@@ -69,7 +69,7 @@ for i, (label, cmd, b2) in enumerate(candidates):
         pkt = make_pkt(cmd, b2)
         resp = send_recv(ser, pkt, wait=0.3)
         rx = resp.hex(" ") if resp else "(none)"
-        print(f"  [{rep+1}] TX: {pkt.hex(' ')}  RX: {rx}")
+        print(f"  [{rep + 1}] TX: {pkt.hex(' ')}  RX: {rx}")
     note = input("  Display change after 3 sends? ")
     print(f"  >> {note}\n")
 

--- a/tools/archive/interactive_volume.py
+++ b/tools/archive/interactive_volume.py
@@ -69,7 +69,7 @@ probes = [
 ]
 
 for i, (label, cmd, b2, b3, b4) in enumerate(probes):
-    print(f"--- [{i+1}/{len(probes)}] {label} ---")
+    print(f"--- [{i + 1}/{len(probes)}] {label} ---")
     ans = input("Press ENTER to send (or 'q' to quit): ")
     if ans.strip().lower() == "q":
         break

--- a/tools/archive/listen_after_handshake.py
+++ b/tools/archive/listen_after_handshake.py
@@ -71,7 +71,7 @@ def main() -> None:
                         pkt = data[i : i + 6]
                         if len(pkt) == 6:
                             print(
-                                f"         pkt[{i//6}]: hdr=0x{pkt[0]:02X} cmd=0x{pkt[1]:02X} "
+                                f"         pkt[{i // 6}]: hdr=0x{pkt[0]:02X} cmd=0x{pkt[1]:02X} "
                                 f"b2=0x{pkt[2]:02X} b3=0x{pkt[3]:02X} b4=0x{pkt[4]:02X} "
                                 f"ck=0x{pkt[5]:02X}"
                             )

--- a/tools/archive/probe_b_slow.py
+++ b/tools/archive/probe_b_slow.py
@@ -68,7 +68,7 @@ def main() -> None:
 
     for i, (label, cmd, b2) in enumerate(probes):
         pkt = make_pkt(cmd, b2)
-        print(f"\n[{i+1}/{len(probes)}] >>> {label}")
+        print(f"\n[{i + 1}/{len(probes)}] >>> {label}")
         print(f"    TX: {pkt.hex(' ')}")
         resp = send_recv(ser, pkt)
         print(f"    RX: {resp.hex(' ') if resp else '(none)'}")

--- a/tools/archive/read_volume_change.py
+++ b/tools/archive/read_volume_change.py
@@ -41,7 +41,7 @@ def read_all(ser: serial.Serial) -> dict[str, bytes]:
     ]:
         results[name] = send_recv(ser, make_pkt(cmd))
     for cmd in range(0xB0, 0xB8):
-        results[f"B{cmd-0xB0}"] = send_recv(ser, make_pkt(cmd, 0x00))
+        results[f"B{cmd - 0xB0}"] = send_recv(ser, make_pkt(cmd, 0x00))
     return results
 
 

--- a/tools/archive/test_a6_at_max.py
+++ b/tools/archive/test_a6_at_max.py
@@ -52,7 +52,7 @@ tests = [
 ]
 
 for i, (label, vol) in enumerate(tests):
-    print(f"--- [{i+1}/{len(tests)}] {label} ---")
+    print(f"--- [{i + 1}/{len(tests)}] {label} ---")
     input("Press ENTER: ")
 
     if vol is not None:

--- a/tools/archive/test_a6_then_aspirate.py
+++ b/tools/archive/test_a6_then_aspirate.py
@@ -56,7 +56,7 @@ tests = [
 ]
 
 for i, (label, vol) in enumerate(tests):
-    print(f"--- [{i+1}/{len(tests)}] {label} ---")
+    print(f"--- [{i + 1}/{len(tests)}] {label} ---")
     input("Press ENTER (watch how much it draws): ")
 
     if vol is not None:

--- a/tools/interactive_probe.py
+++ b/tools/interactive_probe.py
@@ -46,7 +46,7 @@ cmds = [
 ]
 
 for i, (label, cmd, b2) in enumerate(cmds):
-    print(f"--- [{i+1}/{len(cmds)}] {label} ---")
+    print(f"--- [{i + 1}/{len(cmds)}] {label} ---")
     ans = input("Press ENTER to send (or 'q' to quit): ")
     if ans.strip().lower() == "q":
         break


### PR DESCRIPTION
## Summary
- Add AGENTS.md, AGENT_LEARNINGS.md, CONTRIBUTING.md governance docs
- Add CI workflow (ruff + mypy + pytest) and links workflow (lychee)
- Add .claude/ settings, rules (serial-protocol, tools-hygiene)
- Add pyproject.toml complexity gates (C90, mccabe, complexipy)
- Add docs/LICENSING_ASSESSMENT.md for public release review
- Remove vendor document from git history

## Test plan
- [ ] `make validate` passes
- [ ] `make check_links` passes

Generated with Claude <noreply@anthropic.com>