### PR TITLE
ci: pin actions to SHAs and rename CodeQL job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9  # v7
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze
+    name: CodeQL
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,9 +18,9 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: github/codeql-action/init@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: github/codeql-action/init@dc73d59c2d7bd4f8194098a91219eeee6d8a1719  # v4
         with:
           languages: python
-      - uses: github/codeql-action/autobuild@v4
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/autobuild@dc73d59c2d7bd4f8194098a91219eeee6d8a1719  # v4
+      - uses: github/codeql-action/analyze@dc73d59c2d7bd4f8194098a91219eeee6d8a1719  # v4

--- a/.github/workflows/generate-sbom.yaml
+++ b/.github/workflows/generate-sbom.yaml
@@ -15,8 +15,8 @@ jobs:
   generate-sbom:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - uses: qte77/gha-sbom-action@v0
+      - uses: qte77/gha-sbom-action@cd873b1278a6793a99cfe199c01d603d72cca717  # v0.1.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -19,18 +19,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Lychee link check
         id: lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2
         with:
           args: "--config .lychee.toml ."
           fail: true
 
       - name: Create issue on failure
         if: failure()
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553  # v9
         with:
           script: |
             const title = "Broken links detected";

--- a/.github/workflows/write-llms-txt.yaml
+++ b/.github/workflows/write-llms-txt.yaml
@@ -22,7 +22,7 @@ jobs:
       REPO: ${{ github.repository }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Validate template links exist
         run: |


### PR DESCRIPTION
## Summary
- **Pin all third-party actions to commit SHAs** (org policy was rejecting unpinned tag refs, breaking every workflow on every PR). Version comments are kept so dependabot can still bump them.
- **Rename CodeQL job** from `Analyze` to `CodeQL` so the check label is self-describing.

## Pinned versions
| Action | Tag | SHA |
| --- | --- | --- |
| actions/checkout | v6 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| actions/github-script | v9 | `373c709c69115d41ff229c7e5df9f8788daa9553` |
| astral-sh/setup-uv | v7 | `94527f2e458b27549849d47d273a16bec83a01e9` |
| github/codeql-action | v4 | `dc73d59c2d7bd4f8194098a91219eeee6d8a1719` |
| lycheeverse/lychee-action | v2 | `8646ba30535128ac92d33dfc9133794bfdd9b411` |
| qte77/gha-sbom-action | v0.1.1 | `cd873b1278a6793a99cfe199c01d603d72cca717` |

Note: `qte77/gha-sbom-action@v0` did not exist as a tag — pinned to the actual release `v0.1.1`.

## Test plan
- [ ] All workflows reach "Set up job" successfully on this PR (was failing for unpinned actions).
- [ ] CodeQL check appears as `CodeQL / CodeQL` rather than `CodeQL / Analyze`.
- [ ] No required-status-check name changes break branch protection (if `Analyze` was required, update protection rule to `CodeQL`).

Generated with Claude <noreply@anthropic.com>