### PR TITLE
docs: fix markdownlint violations

### DIFF
--- a/.claude/rules/serial-protocol.md
+++ b/.claude/rules/serial-protocol.md
@@ -1,9 +1,11 @@
 # Serial Protocol Safety
 
 ## Packet format
+
 All packets are exactly 6 bytes: `[0xFE] [CMD] [B2] [B3] [B4] [CHECKSUM]`
 
 ## Critical constraints
+
 - **NEVER send `A5 b2=1`** (calibration mode entry) — causes persistent Err4
   that survives reboots and cannot be cleared via serial
 - Only send packets produced by `protocol.encode_packet()`; raw hand-crafted
@@ -12,6 +14,7 @@ All packets are exactly 6 bytes: `[0xFE] [CMD] [B2] [B3] [B4] [CHECKSUM]`
   `safety.validate_speed()` before transmission
 
 ## EEPROM writes
+
 Writing incorrect calibration values (k/b coefficients) via `A4` can break
 motor control. `write_ee()` is provisional — do not use without understanding
 the exact byte layout.

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,6 +2,8 @@
   "default": true,
   "MD013": false,
   "MD024": { "siblings_only": true },
+  "MD025": { "front_matter_title": "" },
   "MD033": false,
-  "MD041": false
+  "MD041": false,
+  "MD060": false
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ pipettes. Provides full serial volume control over USB-UART (CP2102) at
 
 ## Architecture
 
-```
+```text
 src/dpette/
   driver.py        — High-level API (connect, aspirate, dispense, mix, split, dilute)
   protocol.py      — 6-byte packet encode/decode, command enums, working modes
@@ -19,12 +19,14 @@ src/dpette/
 ## Domain Rules
 
 ### Protocol invariants
+
 - All packets are exactly 6 bytes: `[0xFE] [CMD] [B2] [B3] [B4] [CHECKSUM]`
 - Checksum = `sum(bytes[1:5]) & 0xFF`
 - Volumes are encoded as micro-litres x 100 in 24-bit big-endian
 - B3 (KEY) commands produce a **double response** — always read both
 
 ### Safety-critical constraints
+
 - **NEVER send `A5 b2=1`** (calibration mode entry) — causes persistent
   Err4 that survives reboots and cannot be cleared via serial
 - `driver.py` must only send packets produced by `protocol.encode_packet()`;
@@ -34,15 +36,18 @@ src/dpette/
 - Cycle counter (`MAX_CONTIGUOUS_CYCLES = 50`) prevents unattended runaway
 
 ### DI mode workaround
+
 B3 blow does not trigger the motor on basic dPette in dilution mode.
 Workaround: call `enter_mode(WorkingMode.PI)` which homes the motor and
 expels liquid.
 
 ### Piston return suction
+
 B3 blow includes a piston return to home position. If the tip is submerged,
 this draws extra liquid. Always dispense with tip above liquid surface.
 
 ### EEPROM writes
+
 Writing incorrect calibration values (k/b coefficients) via `A4` can break
 motor control. `write_ee()` is provisional — do not use without understanding
 the exact byte layout.
@@ -63,6 +68,7 @@ make check_docs        # markdownlint
 ```
 
 Tests requiring a physical device use `@pytest.mark.hardware` and run with:
+
 ```bash
 pytest -m hardware
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ All tests use mock serial ports — you don't need a pipette connected.
 
 ## Code structure
 
-```
+```text
 src/dpette/
   protocol.py      — packet encode/decode (the protocol bible)
   driver.py        — high-level API (connect, aspirate, dispense)
@@ -49,6 +49,7 @@ docs/              — protocol spec, experiment log, hardware notes
 When probing the device with new commands, follow this pattern:
 
 1. **Create an interactive script** in `tools/` with logging:
+
    ```python
    LOGFILE = "captures/live_log.txt"
    _log = open(LOGFILE, "w")

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ mypy src/               # type check
 
 All communication uses 6-byte packets:
 
-```
+```text
 [0xFE] [CMD] [B2] [B3] [B4] [CHECKSUM]   host → device
 [0xFD] [CMD] [B2] [B3] [B4] [CHECKSUM]   device → host
 ```

--- a/docs/EXPERIMENT_LOG.md
+++ b/docs/EXPERIMENT_LOG.md
@@ -52,10 +52,12 @@ not the app binary. The 7-byte format was wrong.
 `mov edx, 0xfffffffe` (header), `mov edx, 0xffffffa4` (WriteEE),
 `mov edx, 0xffffffa6` (SendCaliVolume), `mov edx, 0xffffffa5` (HandShake)
 **Result:** ✅ **FIRST CONTACT** — HandShake responded:
-```
+
+```text
 TX: fe a5 00 00 00 a5
 RX: fd a5 00 00 00 a5
 ```
+
 **Key finding:** TX header=0xFE, RX header=0xFD, 6-byte packets, checksum validated
 
 ---
@@ -84,6 +86,7 @@ addresses 0x37-0xFF → response b2=0x01. Not actual data.
 
 **Script:** `tools/probe_response_format.py`
 **Key findings:**
+
 - Bad checksums → no response (checksum IS validated)
 - 7-byte packets → no response (format IS 6 bytes)
 - CMD=0xA3 returns different byte[2] values depending on device state
@@ -113,6 +116,7 @@ Three write format hypotheses all failed to produce readable changes.
 
 **Script:** `tools/brute_cmd.py`
 **Result:** ✅ **MAJOR DISCOVERY** — 17 responding commands:
+
 - 0xA0-0xA8 (calibration range, previously known)
 - **0xB0-0xB7** (new range! previously untested)
 - 0xA1, 0xA2 return **13-byte** responses (not 6)
@@ -123,6 +127,7 @@ Three write format hypotheses all failed to produce readable changes.
 
 **Script:** `tools/interactive_probe.py` (run by user in terminal)
 **Result:** ✅ **MOTOR CONTROL FOUND:**
+
 - **B3 b2=0x01 = ASPIRATE** — 12-byte double response, confirmed motor movement
 - **B0 b2=0x01 = DISPENSE** — 6-byte response, confirmed motor movement
 - B1, B2, B4-B7 = no visible effect
@@ -173,6 +178,7 @@ Tested with ×10 encoding, raw encoding, and b4=1 trigger flag.
 **Script:** `tools/test_a6_then_aspirate.py`
 **Hypothesis:** A6 sets motor travel, then B3 aspirates at that volume
 **Results (display at 100 µL):**
+
 - A6=30 → drew 30 µL ← appeared to work!
 - A6=150 → drew 100 µL ← did not work
 - A6=300 → drew 100 µL ← did not work
@@ -194,6 +200,7 @@ A6 does NOT control motor travel in normal mode.
 
 **Script:** `tools/test_cali_mode.py`
 **Result:** ✅ **BREAKTHROUGH:**
+
 - A5 b2=1 enters calibration mode (different display menu)
 - **A6=50 changed display to 50 µL in cal mode**
 - **A6=150 changed display to 150 µL in cal mode**
@@ -207,6 +214,7 @@ A6 does NOT control motor travel in normal mode.
 
 **Script:** `tools/test_cali_volume_persist.py`
 **Result:** Partial success:
+
 - Set 50 µL via cal mode → aspirate drew 50 µL ✅
 - Set 150 µL via cal mode → aspirate drew 50 µL ❌ (first value stuck)
 - Set 250 µL via cal mode → aspirate drew 50 µL ❌
@@ -246,9 +254,11 @@ completed the calibration session in the device's state machine.
 
 **Script:** `tools/exit_cal_and_test.py`
 **Result:** ✅ **FIX FOUND:**
-```
+
+```text
 Handshake (A5 b2=0) → Enter cal (A5 b2=1) → Exit cal (A5 b2=0) → B3 aspirate WORKS
 ```
+
 The cal mode toggle clears the stale state that blocks B3.
 Motor OK — 12-byte double response confirmed.
 
@@ -277,6 +287,7 @@ A0 (b2=0/1), A7 (b2=0/1), B1-B7 (b2=1)
 | 150 µL    | (in cal)| No (re-sent A5 b2=1 in cal)   |
 
 **Conclusion:** The complete remote pipetting flow is:
+
 1. `A5 b2=0` (handshake)
 2. `A6` (set volume)
 3. `A5 b2=1` (enter cal mode = ASPIRATE at A6 volume)
@@ -327,6 +338,7 @@ through the calibration protocol alone.**
 
 **Device:** Second dPette, 10-100 µL range, never touched before
 **Results:**
+
 - Handshake works ✓
 - B3 b2=1 alone → REJECTED (same as corrupted device)
 - A5 b2=1 (enter cal) → causes persistent Err4, NO motor movement
@@ -342,6 +354,7 @@ A5 b2=1 causes Err4 on clean devices too.
 **Device:** 10-100 µL dPette (in cal mode state from EXP-027)
 **Sequence:** Handshake → B0 b2=1 → B3 b2=1
 **Result:** ✅ **B3 WORKS after B0 prime!**
+
 - B0 b2=1: 6-byte ACK
 - B3 b2=1: 12-byte double response, motor aspirated
 - Repeated 3 times successfully
@@ -410,6 +423,7 @@ Write: `FE A4 00 [ADDR] [VALUE] [CHECKSUM]` — address in byte[3], value in byt
 All our prior EEPROM attempts failed because we put the address in byte[2].
 
 **PetteCali calibration sequence observed:**
+
 1. `FE A8 01 68 09 38` — device config/init
 2. `FE A0 00 00 00 A0` — status check (×2)
 3. `FE A3 00 80..AD` — read all EEPROM (46 addresses, each sent twice)
@@ -420,12 +434,14 @@ All our prior EEPROM attempts failed because we put the address in byte[2].
 8. `FE A5` — handshake close
 
 **WriteData sequence:**
+
 - `FE A4 00 90..9F [VALUE]` — write k/b coefficients (seg1 + seg2)
 - `FE A0` — status check
 - `FE A3 00 80..AD` — re-read all EEPROM to verify
 - Each write sent twice (retry pattern)
 
 **WriteEE values captured (k=1.2268, b=0.0000):**
+
 - 0x90: 0x00, 0x91: 0x00, 0x92: 0x2F, 0x93: 0xEC (k bytes)
 - 0x94-0x97: all 0x00 (b bytes)
 - 0x98-0x9F: same pattern for seg2
@@ -434,7 +450,7 @@ All our prior EEPROM attempts failed because we put the address in byte[2].
 
 ### Summary of confirmed working protocol
 
-```
+```text
 Handshake  [FE A5 00 00 00 A5]
 B0 prime   [FE B0 01 00 00 B1]  ← once per session, primes piston
 B3 aspirate [FE B3 01 00 00 B4] → 12-byte response, aspirates at dial vol
@@ -449,6 +465,7 @@ Tested on both 10-100 µL (clean) and 30-300 µL (recalibrated) devices.
 
 **Device:** 30-300 µL dPette
 **Result:** Full EEPROM dump revealed:
+
 - 0x00: zero (only zero among surrounding 0xFF bytes)
 - 0x01-0x3F: all 0xFF (unused/erased EEPROM)
 - 0x42: 0x00 (zero among 0xFF — tested as Err4 flag, NOT it)
@@ -458,6 +475,7 @@ Tested on both 10-100 µL (clean) and 30-300 µL (recalibrated) devices.
 - 0xD2-0xD3: 0x0B 0xB8 = 3000 (300 µL × 10)
 
 **Err4 flag tests:**
+
 - Wrote 0xFF to 0x42 → error changed to Err2, restored to 0x00
 - Wrote 0x00 to 0xC4/0xC5 → no change
 - Wrote 0x03 to 0x80 (cal point count) → no change
@@ -500,6 +518,7 @@ This is exactly how PetteCali's calibration works: software sets the
 volume, user presses the button to aspirate at each measurement point.
 
 **Complete remote volume control flow (requires physical button actuation):**
+
 1. Enter cal mode: `FE A5 01 00 00 A6` (dismiss Err4)
 2. Set volume: `FE A6 [vol_hi] [vol_lo] 00 [cksum]` (vol = µL × 10)
 3. Physical button press → aspirates at A6 volume
@@ -508,6 +527,7 @@ volume, user presses the button to aspirate at each measurement point.
 
 **Remaining blocker:** The physical button press cannot be triggered via
 serial. For full automation, need either:
+
 - Physical actuator (servo/solenoid) on the button
 - RP2040 MitM intercepting the button GPIO line
 - Firmware patch to add a serial button-press command
@@ -617,13 +637,15 @@ cycle with volume changes between aspirations.
 | Dispense | B0 serial | — | ✅ dispensed |
 
 **Also confirmed:**
+
 - B0 dispense works immediately after button aspirate in cal mode ✓
 - A6 can change volume between cycles without exiting cal mode ✓
 - B3 is rejected in cal mode (as expected) ✓
 - No need to exit/re-enter cal mode between cycles ✓
 
 **Confirmed automation flow (requires MOSFET on button):**
-```
+
+```text
 Enter cal mode (once) → for each cycle:
   A6 set volume (serial) → button press (MOSFET) → B0 dispense (serial)
 ```
@@ -708,6 +730,7 @@ provide volume-controlled aspiration via serial.
 **Device:** 30-300 µL dPette
 **Hypothesis:** CP2102 DTR/RTS lines may be wired to MCU reset/boot pins
 **Tested:**
+
 - DTR toggle (reset) — no display change
 - RTS toggle — no change
 - DTR+RTS together (boot mode) — no change, no bootloader response
@@ -745,6 +768,7 @@ PetteCali). The remote control interface uses A0/B0/B1/B2/B3.
 **Device:** dPette on /dev/cu.usbserial-0001
 **Script:** `examples/test_remote_mode.py`
 **Results:**
+
 - A0 handshake: accepted (p1=0) — this is the REAL handshake, not A5
 - B0 param=1 (enter PI mode): accepted, motor homed
 - B1 speed control (suck=2, blow=2): both accepted
@@ -766,6 +790,7 @@ prior experiments). B2 volume was accepted but needed volume verification.
 If motor travel matches B2 (not dial), volume control is confirmed.
 
 **Results:**
+
 - Trial 1 (B2=50 uL): motor moved, display changed to 50, SMALL aspirate
 - Trial 2 (B2=200 uL): motor moved, display changed to 200, MEDIUM aspirate
 - Trial 3 (B2=50 uL): motor moved, display changed to 50, SMALL aspirate
@@ -777,7 +802,8 @@ between 50 and 200 uL trials.
 **CONCLUSION: Remote serial volume control is CONFIRMED.**
 
 The correct workflow is:
-```
+
+```text
 A0 (handshake) → B0 param=1 (PI mode) → B2 vol×100 (set volume) → B3 param=1 (aspirate) → B3 param=2 (dispense)
 ```
 

--- a/docs/HARDWARE_MOD.md
+++ b/docs/HARDWARE_MOD.md
@@ -50,7 +50,7 @@ All items are in stock with 1–2 business day delivery.
 The DEBO LOGIC 4CH board exposes 4× BSS138 MOSFETs on 2.54mm headers.
 Use one channel (e.g. channel 1):
 
-```
+```text
 Pico GP15 ──── LV1 pin (board)
 Pico 3V3  ──── LV  pin (board)
 Pico GND  ──── GND pin (LV side)
@@ -75,8 +75,9 @@ Place the 40-pin header strip into the breadboard (to hold it straight), rest
 the Pico on top, solder all 40 pins. ~10 minutes.
 
 **2. Flash MicroPython firmware**  
+
 - Hold `BOOTSEL` while plugging in the micro-USB cable → mounts as `RPI-RP2`
-- Download MicroPython `.uf2` from https://micropython.org/download/RPI_PICO2
+- Download MicroPython `.uf2` from <https://micropython.org/download/RPI_PICO2>
 - Drag the `.uf2` onto the `RPI-RP2` drive → Pico reboots automatically
 
 **3. Verify in REPL**  
@@ -87,9 +88,9 @@ Type `print("ok")` at the `>>>` prompt to confirm firmware is running.
 
 ### Phase B — Wire the level shifter
 
-**4. Insert DEBO LOGIC 4CH into breadboard**
+#### 4. Insert DEBO LOGIC 4CH into breadboard
 
-**5. Connect Pico → level shifter**
+#### 5. Connect Pico → level shifter
 
 | Pico pin | Board pin | Notes |
 |----------|-----------|-------|
@@ -115,6 +116,7 @@ Set multimeter to continuity mode. Probe the button pads while pressing it —
 beeps when you find the two pads that complete the circuit.
 
 **9. Solder two short wires (~5cm) to the button pads**  
+
 - Apply flux to each pad
 - Tin the pad, tack one wire per pad
 - Verify no solder bridges to adjacent components
@@ -122,7 +124,7 @@ beeps when you find the two pads that complete the circuit.
 **10. Route wires out of the pipette**  
 Thread wires through a gap in the case seam or a 2mm drilled hole. Close the case.
 
-**11. Connect button wires to level shifter**
+#### 11. Connect button wires to level shifter
 
 | Wire | Board pin |
 |------|-----------|
@@ -133,7 +135,7 @@ Thread wires through a gap in the case seam or a 2mm drilled hole. Close the cas
 
 ### Phase D — Test
 
-**12. Quick MicroPython test**
+#### 12. Quick MicroPython test
 
 ```python
 from machine import Pin
@@ -148,7 +150,7 @@ button.value(0)    # MOSFET OFF → button released
 With the pipette in calibration mode and A6 set, this should trigger
 aspiration. You should hear the motor.
 
-**13. Full automation cycle test**
+#### 13. Full automation cycle test
 
 ```python
 # Enter cal mode via MOSFET button press (NOT serial A5 b2=1 — causes Err4)

--- a/docs/LICENSING_ASSESSMENT.md
+++ b/docs/LICENSING_ASSESSMENT.md
@@ -13,9 +13,9 @@ Reverse engineering of communication protocols for interoperability is
 protected under:
 
 - **US:** DMCA §1201(f) interoperability exception
-  — https://www.law.cornell.edu/uscode/text/17/1201
+  — <https://www.law.cornell.edu/uscode/text/17/1201>
 - **EU:** Software Directive 2009/24/EC, Article 6
-  — https://eur-lex.europa.eu/eli/dir/2009/24/oj
+  — <https://eur-lex.europa.eu/eli/dir/2009/24/oj>
 
 No DRM, encryption, or access controls are circumvented. The driver observes
 and speaks a plaintext serial protocol over standard UART hardware.
@@ -46,5 +46,5 @@ and speaks a plaintext serial protocol over standard UART hardware.
 
 ## References
 
-- DLAB Scientific (vendor): https://www.dlab.com.cn
+- DLAB Scientific (vendor): <https://www.dlab.com.cn>
 - xg590/Learn_dPettePlus (prior art, third-party RE): referenced in README

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -9,7 +9,7 @@ owner: "lambda biolab"
 
 ## Physical architecture
 
-```
+```text
 ┌──────────────────────────────────────────────────────────┐
 │ Host PC                                                  │
 │                                                          │
@@ -91,7 +91,7 @@ owner: "lambda biolab"
 
 ## Dependency rules
 
-```
+```text
 driver.py  →  safety.py
 driver.py  →  protocol.py  →  (no further internal deps)
 driver.py  →  serial_link.py  →  pyserial

--- a/docs/PROTOCOL_NOTES.md
+++ b/docs/PROTOCOL_NOTES.md
@@ -34,12 +34,13 @@ Actual application binary: `captures/static-analysis/extracted/app/PetteCali.exe
 
 All packets are **6 bytes**:
 
-```
+```text
 [HEADER] [CMD] [B2] [B3] [B4] [CHECKSUM]
  1 byte  1 byte 1    1    1     1 byte
 ```
 
 **Header bytes:**
+
 - Host → device: `0xFE`
 - Device → host: `0xFD`
 
@@ -88,7 +89,7 @@ before `call rbx` (QByteArray::append) in each packet-builder function.
 
 **HandShake / StartCalibrate (0xA5):**
 
-```
+```text
 TX: [FE] [A5] [param] [00] [00] [cksum]
 RX: [FD] [A5] [00]    [00] [00] [A5]
 ```
@@ -104,7 +105,7 @@ RX: [FD] [A5] [00]    [00] [00] [A5]
 
 **SendCaliVolume (0xA6):**
 
-```
+```text
 TX: [FE] [A6] [vol_hi] [vol_lo] [00] [cksum]
 RX: [FD] [A6] [00]     [00]     [00] [A6]
 ```
@@ -120,7 +121,7 @@ RX: [FD] [A6] [00]     [00]     [00] [A6]
 
 **WriteEE (0xA4) — CONFIRMED from PetteCali capture:**
 
-```
+```text
 TX: [FE] [A4] [00] [ADDR] [VALUE] [cksum]
 RX: [FD] [A4] [??] [00]   [00]   [cksum]
 ```
@@ -132,7 +133,7 @@ RX: [FD] [A4] [??] [00]   [00]   [cksum]
 
 **ReadEE (0xA3) — CONFIRMED from PetteCali capture:**
 
-```
+```text
 TX: [FE] [A3] [00] [ADDR] [00] [cksum]
 RX: [FD] [A3] [VALUE] [00] [00] [cksum]
 ```
@@ -145,7 +146,7 @@ RX: [FD] [A3] [VALUE] [00] [00] [cksum]
 
 **Aspirate (0xB3) — CONFIRMED live, motor movement:**
 
-```
+```text
 TX: [FE] [B3] [01] [00] [00] [B4]
 RX: [FD] [B3] [00] [00] [00] [B3]   ← motor started
     [FD] [B3] [01] [00] [00] [B4]   ← motor finished (12 bytes total)
@@ -161,7 +162,7 @@ RX: [FD] [B3] [00] [00] [00] [B3]   ← motor started
 
 **Dispense / Prime (0xB0) — CONFIRMED live, motor movement:**
 
-```
+```text
 TX: [FE] [B0] [01] [00] [00] [B1]
 RX: [FD] [B0] [00] [00] [00] [B0]
 ```
@@ -175,7 +176,7 @@ RX: [FD] [B0] [00] [00] [00] [B0]
 
 **Data dump commands (0xA1, 0xA2) — 13-byte responses:**
 
-```
+```text
 TX: [FE] [A1] [b2] [b3] [b4] [cksum]
 RX: [FD] [A1] [00] [00] [00] [00] [00] [00] [00] [00] [00] [00] [A1]
 ```
@@ -189,7 +190,7 @@ RX: [FD] [A1] [00] [00] [00] [00] [00] [00] [00] [00] [00] [00] [A1]
 
 All observed device responses are 6 bytes:
 
-```
+```text
 [0xFD] [CMD_ECHO] [B2] [B3] [B4] [CHECKSUM]
 ```
 
@@ -292,6 +293,7 @@ FUN_14001d850 (`readData` slot, connected to `QSerialPort::readyRead`):
    which EEPROM address was being read, extracts value via FUN_140069e00
 
 FUN_14001af80 (buffered frame parser):
+
 - Same dispatch logic for frames assembled across multiple readyRead calls
 - Same flag-based state machine for 0xA3 data
 
@@ -304,7 +306,7 @@ Response timeout: 1000ms per read (`_timerRead->start(1000)`).
 Tested on clean dPette 10-100 µL.  Set volume on the physical dial,
 then control aspirate/dispense remotely.
 
-```
+```text
 ┌─────────────────────────────────────────────────────────┐
 │ Prerequisites:                                          │
 │   - Set volume on pipette dial/buttons                  │
@@ -343,7 +345,8 @@ confirmed way to change the volume remotely via serial commands.
 NOT the calibration interface (A6).**
 
 The correct sequence is:
-```
+
+```text
 A0 (handshake) → B0 param=1 (enter PI mode) → B2 vol×100 (set volume)
   → B3 param=1 (aspirate) → B3 param=2 (dispense)
 ```
@@ -364,7 +367,7 @@ correct command for runtime volume control in PI mode.
 The following command **permanently damages device state** and should
 NOT be sent during normal operation:
 
-```
+```text
 ⚠️  [FE A5 01 00 00 A6]  — Enter Calibration Mode (A5 b2=1)
 ```
 
@@ -382,6 +385,7 @@ it.  The error must be dismissed with the physical button on every
 boot; all serial operations work normally after dismissal.
 
 **Other risky commands:**
+
 - `A4` (WriteEE) — writes to device EEPROM.  Incorrect values can
   affect calibration accuracy.  Our experiments wrote k=1.2313,
   b=0.0000 to the 30-300 device, which may have broken motor control


### PR DESCRIPTION
## Summary
Cleans up all markdownlint violations the project picked up over time (208 → 0). Two topical commits:

1. **Config tweaks** — `MD025.front_matter_title=""` (keep both YAML title and rendered H1) and `MD060: false` (multilingual tables can't satisfy char-count alignment).
2. **Content fixes** — auto-fixed blank lines around headings/fences/lists, added `text` language to plain code fences, wrapped bare URLs, and promoted stand-alone bolded step labels in `docs/HARDWARE_MOD.md` to real H4 headings. No content changes.

`MD013` (line length) remains disabled — preserved per the existing config.

## Test plan
- [ ] `make check_docs` passes locally.
- [ ] CI `check-links` continues to pass (link checker is unrelated; no link content changed).

Generated with Claude <noreply@anthropic.com>