### PR TITLE
ci(codeql): build-mode none, security-extended, paths-ignore

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,5 +22,10 @@ jobs:
       - uses: github/codeql-action/init@dc73d59c2d7bd4f8194098a91219eeee6d8a1719  # v4
         with:
           languages: python
-      - uses: github/codeql-action/autobuild@dc73d59c2d7bd4f8194098a91219eeee6d8a1719  # v4
+          build-mode: none
+          queries: security-extended
+          config: |
+            paths-ignore:
+              - tools/archive/**
+              - docs/**
       - uses: github/codeql-action/analyze@dc73d59c2d7bd4f8194098a91219eeee6d8a1719  # v4


### PR DESCRIPTION
## Summary
Three low-risk upgrades to the Python CodeQL workflow:

| Change | Why |
| --- | --- |
| Drop `autobuild`, set `build-mode: none` on the init step | Python doesn't need a build for CodeQL. Removes a wasted step. |
| Add `queries: security-extended` | Default suite is conservative; extended catches more real issues with low FP on a codebase this size. |
| Add `paths-ignore` for `tools/archive/**` and `docs/**` | Archive holds one-off probing scripts; docs is markdown. Both produce noise without value. |

No behaviour change to the rest of the workflow (still pinned to SHAs, same schedule, same permissions).

## Test plan
- [ ] CodeQL check runs to completion on this PR (replaces previous autobuild path with build-mode none).
- [ ] Resulting alerts (if any) come only from `src/` and `tests/`, not `tools/archive/` or `docs/`.
- [ ] No new high-severity alerts that weren't present on `main` before this change (run is informational, not blocking).

Generated with Claude <noreply@anthropic.com>