### PR TITLE
docs: fix P1 stale claims (post-EXP-050 incoherences)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,8 +83,10 @@ via serial.  See `docs/SAFETY_MODEL.md` and GitHub issue #2.
 
 ## Hardware modification
 
-Full volume control requires a BSS138 MOSFET wired across the pipette's
-button contacts.  See GitHub issue #3 for the wiring guide and BOM.
+Not required.  Full volume control runs over serial via the `B2` (PI_VOLUM)
+command (confirmed in EXP-050).  An optional BSS138 MOSFET mod for
+button-press automation is documented in `docs/HARDWARE_MOD.md` for users
+who want fully untouched-by-hand operation.
 
 ## Pull requests
 

--- a/docs/HARDWARE_MOD.md
+++ b/docs/HARDWARE_MOD.md
@@ -1,18 +1,24 @@
 # dPette Button MOSFET Mod — Hardware Guide
 
-This document covers the hardware modification required for fully automated,
-volume-controlled pipetting. The mod wires a BSS138 MOSFET across the pipette's
-physical button contacts, allowing any microcontroller GPIO pin to simulate a
-button press electronically.
+This document covers an **optional** hardware modification for fully hands-off
+operation. The mod wires a BSS138 MOSFET across the pipette's physical button
+contacts, allowing any microcontroller GPIO pin to simulate a button press
+electronically.
 
-## Why this is needed
+## When you need this
 
-The dPette's volume control (A6 command) only takes effect when the physical
-button is pressed — there is no serial command that triggers aspiration at the
-A6-set volume. After 48 experiments exhausting the full serial protocol surface,
-a hardware button actuator is the confirmed path to full automation.
+For most callers, the mod is unnecessary — `B2` (PI_VOLUM) sets motor travel
+remotely and `B3` triggers aspirate/dispense over serial (confirmed in EXP-050).
+The MOSFET mod is only useful if you also want to enter calibration mode
+hands-off (which is the one workflow that still requires a physical button
+press, since the serial `A5 b2=1` equivalent causes persistent Err4).
 
-See [`EXPERIMENT_LOG.md`](EXPERIMENT_LOG.md) for the complete investigation.
+The mod was originally developed before EXP-050 proved B2 worked, when a
+hardware button actuator looked like the only path to automation. It is kept
+here as an option for fully untouched-by-hand operation in lab automation
+setups.
+
+See [`EXPERIMENT_LOG.md`](EXPERIMENT_LOG.md) for the full investigation.
 
 ---
 

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -34,7 +34,7 @@ owner: "lambda biolab"
      ┌───────────────┐
      │ CP210x bridge │  Silicon Labs USB-UART
      └───────┬───────┘
-             │ UART (TX/RX, baud TBD)
+             │ UART (TX/RX, 9600 8N1)
              ▼
      ┌───────────────┐
      │ Pipette MCU   │  microcontroller (unknown model)
@@ -46,48 +46,32 @@ owner: "lambda biolab"
      └───────────────┘
 ```
 
-## Project phases
+## How this was built
 
-### Phase 1 — Static analysis (no hardware needed)
+The protocol was decoded in four overlapping passes:
 
-- Download PetteCali.exe from DLAB (QR code link).
-- Decompile with dnSpyEx or ILSpy (runs on Windows, Wine, or natively).
-- Extract: serial port init (baud rate, framing), command strings,
-  packet format, checksum algorithm.
-- Document findings in `docs/PROTOCOL_NOTES.md`.
-
-### Phase 2 — Discovery
-
-- Connect dPette via USB; confirm it appears as `/dev/tty.SLAB_USBtoUART`.
-- Identify VID/PID with `system_profiler` or `cp210x-program`.
-- Confirm baud rate from Phase 1 using `tools/scan_baud.py`.
-
-### Phase 3 — Passive capture
-
-- Listen on the serial port while manually operating the pipette
-  (button presses for aspirate/dispense) — the MCU may emit status
-  bytes or ACKs without the calibration software running.
-- Use `tools/dump_raw.py` or SerialTool for logging.
-- Optionally: run PetteCali in a Windows VM with USBPcap for full
-  bidirectional capture.
-- Store captures in `captures/`.
-
-### Phase 4 — Driver implementation
-
-- Implement `protocol.py` encode/decode based on Phase 1 + 3 findings.
-- Implement `driver.py` command methods.
-- Expand test suite with real packet fixtures.
-- Validate against live hardware using `tools/replay_trace.py`.
+1. **Static analysis** — Ghidra decompilation of `PetteCali.exe` (the
+   official DLAB Windows calibration app — native C++/Qt6, MinGW x86-64).
+   Extracted serial init, packet format, and checksum algorithm.
+2. **Discovery** — confirmed the dPette enumerates as a Silicon Labs
+   CP2102 USB-UART bridge (VID `0x10C4`, PID `0xEA60`), appearing as
+   `/dev/cu.usbserial-0001` on macOS or `/dev/ttyUSB0` on Linux. Baud
+   rate confirmed against Phase 1 findings.
+3. **Live probing** — 55 hardware experiments documented in
+   `EXPERIMENT_LOG.md`. Bidirectional capture via PetteCali in a Windows
+   VM filled the remaining gaps.
+4. **Driver implementation** — `protocol.py` encode/decode, `driver.py`
+   command surface, test suite against mocked serial fixtures, then
+   validation on live hardware.
 
 ## Reference projects
 
 | Project | Relevance |
 |---------|-----------|
-| [ac-rad/digital-pipette-v2](https://github.com/ac-rad/digital-pipette-v2) | DIY pipette with Python serial driver |
+| [ac-rad/digital-pipette](https://github.com/ac-rad/digital-pipette) | DIY pipette with Python serial driver |
 | [SerialTool](https://github.com/Duolabs/SerialTool) | Cross-platform serial sniffer (macOS/Linux) |
 | [cp210x-program](https://github.com/VCTLabs/cp210x-program) | CP210x EEPROM reader (VID/PID) |
-| [dnSpyEx](https://github.com/dnSpyEx/dnSpy) | .NET decompiler/debugger |
-| [ILSpy](https://github.com/icsharpcode/ILSpy) | .NET decompiler (multi-platform) |
+| [Ghidra](https://ghidra-sre.org/) | Native-binary decompiler used on PetteCali.exe |
 
 ## Dependency rules
 


### PR DESCRIPTION
## Summary
Three P1 doc-incoherence fixes flagged by the audit. All three files predated EXP-050 (which proved B2 PI_VOLUM controls motor travel over serial) and never got updated.

| Commit | File | Fix |
|---|---|---|
| `docs(contributing): correct stale MOSFET-required claim` | `CONTRIBUTING.md` | "Hardware modification required" → "Not required. Optional mod for hands-off calibration entry." |
| `docs(overview): rewrite Project phases as past tense, fix stale refs` | `docs/OVERVIEW.md` | Phases 1–4 rewritten as completed work (past tense); decompiler refs corrected (Ghidra, not dnSpyEx/ILSpy — PetteCali is native C++/Qt6); device node corrected (`/dev/cu.usbserial-0001` on macOS, not `/dev/tty.SLAB_USBtoUART`); baud "TBD" → 9600 8N1; ac-rad URL fixed |
| `docs(hardware-mod): reframe MOSFET as optional, not required` | `docs/HARDWARE_MOD.md` | Opener rewritten to position the mod as optional convenience for hands-off calibration entry rather than the "confirmed path to automation" |

## Test plan
- [ ] `make check_docs` passes (verified locally — 0 errors on the three changed files).
- [ ] Cross-reference with README "What works" list — claims still aligned.
- [ ] P2/P3 audit items (Makefile-target drift in CONTRIBUTING, stale "Open questions" in PROTOCOL_NOTES, etc.) deliberately left out of this PR to keep diffs reviewable; will land in a separate follow-up.

Generated with Claude <noreply@anthropic.com>