### PR TITLE
chore(claude): rebalance enabled plugins to the six that earn their keep

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,14 +24,12 @@
   },
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
-    "tdd-core@qte77-claude-code-utils": true,
     "python-dev@qte77-claude-code-utils": true,
     "commit-helper@qte77-claude-code-utils": true,
-    "simplify@qte77-claude-code-utils": true,
+    "gha-dev@qte77-claude-code-utils": true,
+    "codebase-tools@qte77-claude-code-utils": true,
     "docs-governance@qte77-claude-code-utils": true,
-    "makefile-core@qte77-claude-code-utils": true,
-    "cc-meta@qte77-claude-code-utils": true,
-    "workspace-setup@qte77-claude-code-utils": true
+    "cc-meta@qte77-claude-code-utils": true
   },
   "extraKnownMarketplaces": {
     "qte77-claude-code-utils": {


### PR DESCRIPTION
## Summary
Trims `.claude/settings.json` enabled plugins from 9 → 7 (incl. `context7`):

**Removed**
- `tdd-core` — overlaps `python-dev:testing-python`.
- `simplify` — overlaps `python-dev:reviewing-code`.
- `makefile-core` — Makefile is small and stable; auditing it is a one-off.
- `workspace-setup` — would deploy rules/statusline; project already has its own curated `.claude/rules/`.

**Added**
- `gha-dev` — we author and audit GHA workflows (SHA pinning, CodeQL config, link checker) often enough to justify the skills.
- `codebase-tools` — build-error-resolver subagent and hardening flow complement the existing ruff / mypy / pytest gates.

**Kept**
- `context7` (claude-plugins-official) — library docs lookup.
- `python-dev`, `commit-helper`, `docs-governance`, `cc-meta`.

The marketplace pointer is already declared inside `settings.json` under `extraKnownMarketplaces`, so no separate `.claude/marketplace.json` is needed.

## Test plan
- [ ] Open a fresh Claude Code session in this repo and confirm the seven plugins above are loaded (and the four removed ones are not).
- [ ] No SessionStart hook failures introduced by the change.

Generated with Claude <noreply@anthropic.com>