### PR TITLE
docs(readme): wrap dPette image in collapsible details block

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD033 -->
 # dpette-usb-driver
 
 [![License](https://img.shields.io/badge/license-MIT-58f4c2.svg)](LICENSE)
@@ -13,9 +14,14 @@ modes (pipetting, splitting, dilution) — no hardware modifications needed.
 Uses the Silicon Labs **CP2102** USB-UART bridge (VID `0x10C4`, PID `0xEA60`)
 at 9600 baud 8N1.
 
+<details>
+<summary>dPette 8-channel with USB-UART bridge attached</summary>
+
 ![dPette 8-channel with USB-UART bridge attached](docs/dpette-multichannel.png)
 
 *Verified on the 8-channel dPette — same CP2102 bridge, same 6-byte protocol.*
+
+</details>
 
 ## Why this matters
 


### PR DESCRIPTION
## Summary
- Move the `docs/dpette-multichannel.png` image (and its caption) inside `<details>`/`<summary>` so the README's first screen stays focused on badges, intro, and the comparison table.
- Add an inline `<\!-- markdownlint-disable MD033 -->` comment at the top of the README so the file is self-documenting about why inline HTML is intentional here. The project `.markdownlint.json` is **not** modified (it already disables MD033 globally, but the inline disable keeps the README portable).

## Test plan
- [ ] On GitHub, README renders with a closed details block ("dPette 8-channel with USB-UART bridge attached"); clicking expands the image.
- [ ] `make check_docs` stays at 0 errors (verified locally).

Generated with Claude <noreply@anthropic.com>