### PR TITLE
docs(readme): final 6-badge set, pinned to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 <!-- markdownlint-disable MD033 -->
 # dpette-usb-driver
 
-[![License](https://img.shields.io/badge/license-MIT-58f4c2.svg)](LICENSE)
 ![Version](https://img.shields.io/badge/version-0.2.0-58f4c2.svg)
-[![CodeFactor](https://www.codefactor.io/repository/github/lambda-biolab/dpette-usb-driver/badge)](https://www.codefactor.io/repository/github/lambda-biolab/dpette-usb-driver)
-[![CodeQL](https://github.com/Lambda-Biolab/dpette-usb-driver/actions/workflows/codeql.yml/badge.svg)](https://github.com/Lambda-Biolab/dpette-usb-driver/actions/workflows/codeql.yml)
-[![Dependabot Updates](https://github.com/Lambda-Biolab/dpette-usb-driver/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/Lambda-Biolab/dpette-usb-driver/actions/workflows/dependabot/dependabot-updates)
+[![License](https://img.shields.io/badge/license-MIT-58f4c2.svg)](LICENSE)
+[![CI](https://github.com/Lambda-Biolab/dpette-usb-driver/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Lambda-Biolab/dpette-usb-driver/actions/workflows/ci.yml)
+[![Dependabot Updates](https://github.com/Lambda-Biolab/dpette-usb-driver/actions/workflows/dependabot/dependabot-updates/badge.svg?branch=main)](https://github.com/Lambda-Biolab/dpette-usb-driver/actions/workflows/dependabot/dependabot-updates)
+[![CodeQL](https://github.com/Lambda-Biolab/dpette-usb-driver/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/Lambda-Biolab/dpette-usb-driver/actions/workflows/codeql.yml)
+[![CodeFactor](https://www.codefactor.io/repository/github/lambda-biolab/dpette-usb-driver/badge/main)](https://www.codefactor.io/repository/github/lambda-biolab/dpette-usb-driver)
 
 Open-source Python driver for **DLAB dPette** and **dPette+** electronic
 pipettes. Full serial volume control, speed control, and three operating


### PR DESCRIPTION
## Summary
Settles on the six-badge set in order: **Version, License, CI, Dependabot, CodeQL, CodeFactor**.

- Adds the missing **CI** badge for `ci.yml` (was the gap vs issue #22).
- Drops the original spec's separate "Tests" + "Lint" badges — both pointed at the same `ci.yml` workflow and would render identical state. Collapsing to one CI badge.
- **Pins every workflow / service badge to `main`** via `?branch=main` (CodeFactor uses `/badge/main`) so feature-branch PR runs don't flap the visible status.
- Keeps the mint `58f4c2` palette for the static Version + License badges (per the `qte77/pseudonymize-text` style).

## Test plan
- [ ] README renders six badges in the order above on GitHub.
- [ ] All six images load (Version + License are static; the other four are live).
- [ ] After a feature-branch CI run, the main-pinned badge stays at the main status, not the branch status.

Closes #22 (badge portion). Ruff `S` and the CodeFactor finding from that issue are tracked for separate follow-up PRs.

Generated with Claude <noreply@anthropic.com>