### PR TITLE
chore(ruff): graduate the near-free rule families

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,18 @@ ignore = [
 max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
-"tools/*" = ["E501", "B007", "SIM115"]
-"tools/archive/*" = ["E501", "B007", "SIM115", "C901"]
+# tools/ and tools/archive/ contain hardware-probe scripts with scientific
+# notation (µL, en-dashes, etc.) and one-off code; relax style there.
+"tools/*" = ["E501", "B007", "SIM115", "RUF001", "RUF002", "RUF003"]
+"tools/archive/*" = [
+    "E501", "B007", "SIM115", "C901",
+    "RUF001", "RUF002", "RUF003",  # en-dashes and µ are intentional in these notes
+    "S110", "S311", "S404", "S603", "S607",  # archive scripts: subprocess + bare excepts + non-crypto random are fine
+    "TRY300", "TRY301",  # one-off try/except patterns
+    "PGH003",  # bare type: ignore in throwaway code
+    "PT",  # not pytest files
+    "TC",  # type-check-only import discipline not enforced for scripts
+]
 "examples/*" = ["E501"]
 "tests/*" = ["S101", "D"]  # tests use bare assert; docstrings not required
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,15 @@ target-version = "py311"
 src = ["src"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "N", "UP", "B", "A", "SIM", "TCH", "C90"]
+select = [
+    "E", "F", "W", "I", "N", "UP",      # baseline
+    "B", "A", "S", "SIM", "RUF", "PT",  # quality
+    "TC", "PGH", "C90",                 # strictness
+    "TRY",                              # try/except discipline
+]
+ignore = [
+    "TRY003",  # long error messages outside exception classes — noisy on one-off defensive raises
+]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10
@@ -55,6 +63,7 @@ max-complexity = 10
 "tools/*" = ["E501", "B007", "SIM115"]
 "tools/archive/*" = ["E501", "B007", "SIM115", "C901"]
 "examples/*" = ["E501"]
+"tests/*" = ["S101", "D"]  # tests use bare assert; docstrings not required
 
 [tool.mypy]
 python_version = "3.11"

--- a/src/dpette/driver.py
+++ b/src/dpette/driver.py
@@ -107,7 +107,7 @@ class DPetteDriver:
             self._link.open()
             resp = self._transact(hello_packet(), timeout=HANDSHAKE_TIMEOUT_S)
             if resp.cmd != Command.HELLO:
-                raise RuntimeError(
+                raise RuntimeError(  # noqa: TRY301
                     f"Unexpected handshake response cmd 0x{resp.cmd:02X}"
                 )
             log.info("Handshake OK (A0)")
@@ -115,7 +115,7 @@ class DPetteDriver:
             self._cycle_count = 0
             # Enter PI mode now so the motor homes before a tip touches liquid
             self.enter_mode(WorkingMode.PI)
-        except Exception as exc:
+        except (OSError, TimeoutError, RuntimeError) as exc:
             log.warning("dPette connection failed (%s) -- entering stub mode", exc)
             self._stub_mode = True
             self._connected = True

--- a/src/dpette/protocol.py
+++ b/src/dpette/protocol.py
@@ -338,10 +338,14 @@ handshake_packet = demarcate_packet
 (DEMARCATE), not A0 (HELLO).  Use :func:`hello_packet` for the real
 handshake and :func:`demarcate_packet` for calibration mode."""
 
-aspirate_packet = lambda: key_packet(KeyAction.SUCK)  # noqa: E731
-"""Deprecated alias — use ``key_packet(KeyAction.SUCK)``."""
 
-dispense_packet = lambda: wol_packet(WorkingMode.PI)  # noqa: E731
-"""Deprecated alias — the old ``dispense_packet()`` actually sent B0
-(enter PI mode), not B3 blow.  Use ``key_packet(KeyAction.BLOW)`` for
-actual dispense."""
+def aspirate_packet() -> bytes:
+    """Deprecated alias — use ``key_packet(KeyAction.SUCK)``."""
+    return key_packet(KeyAction.SUCK)
+
+
+def dispense_packet() -> bytes:
+    """Deprecated alias — the old ``dispense_packet()`` actually sent B0
+    (enter PI mode), not B3 blow.  Use ``key_packet(KeyAction.BLOW)`` for
+    actual dispense."""
+    return wol_packet(WorkingMode.PI)

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -35,12 +35,12 @@ DEMARCATE_RX = bytes.fromhex("fd a5 00 00 00 a5")
 CALI_VOL_RX = bytes.fromhex("fd a6 00 00 00 a6")
 
 
-@pytest.fixture()
+@pytest.fixture
 def cfg() -> SerialConfig:
     return SerialConfig(port="/dev/ttyUSB0", baudrate=9600)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_serial() -> Generator[MagicMock, None, None]:
     """Yield a mock serial.Serial that returns HELLO + WOL ACKs for connect."""
     with patch("dpette.serial_link.serial.Serial") as cls:
@@ -52,7 +52,7 @@ def mock_serial() -> Generator[MagicMock, None, None]:
         yield port
 
 
-@pytest.fixture()
+@pytest.fixture
 def connected_driver(cfg: SerialConfig, mock_serial: MagicMock) -> DPetteDriver:
     """A driver that has already connected via mock (A0 + B0 consumed)."""
     drv = DPetteDriver(cfg)

--- a/tests/test_serial_link.py
+++ b/tests/test_serial_link.py
@@ -10,7 +10,7 @@ from dpette.config import SerialConfig
 from dpette.serial_link import SerialLink
 
 
-@pytest.fixture()
+@pytest.fixture
 def cfg() -> SerialConfig:
     return SerialConfig(port="/dev/ttyUSB0", baudrate=9600)
 

--- a/tools/quick_test.py
+++ b/tools/quick_test.py
@@ -12,7 +12,7 @@ import time
 import serial
 
 LOGFILE = "/Users/antoniolamb/repos/dpette-usb-driver/captures/live_log.txt"
-_log = open(LOGFILE, "w")  # noqa: SIM115
+_log = open(LOGFILE, "w")
 
 
 def log(msg: str) -> None:

--- a/tools/try_dtr_rts_reset.py
+++ b/tools/try_dtr_rts_reset.py
@@ -15,7 +15,7 @@ import time
 import serial
 
 LOGFILE = "/Users/antoniolamb/repos/dpette-usb-driver/captures/live_log.txt"
-_log = open(LOGFILE, "w")  # noqa: SIM115
+_log = open(LOGFILE, "w")
 PORT = "/dev/cu.usbserial-0001"
 
 


### PR DESCRIPTION
## Summary
First of five planned hardening PRs from the post-session plan. Expands the ruff selection to include `S`, `RUF`, `PT`, `PGH`, `TRY` (and renames the deprecated `TCH` → `TC`); ignores `TRY003` (long messages outside exception classes — noisy).

### Source fixups (all that the new rules actually catch in `src/`)
- `protocol.py` — two deprecated lambda aliases (`aspirate_packet`, `dispense_packet`) converted to `def` functions. Behaviour identical.
- `driver.py` — `connect()` bare `except Exception` narrowed to `(OSError, TimeoutError, RuntimeError)` (the three that can actually fire).
- `driver.py` — `# noqa: TRY301` on the inline handshake-mismatch raise. Extracting a one-shot validation raise to a helper is over-engineering for this case.
- `tests/test_driver.py`, `tests/test_serial_link.py` — auto-fix removes the deprecated `@pytest.fixture()` parentheses.

### Out of scope
- `ANN` and `D` (pydocstyle) — `ANN` is near-zero, but `D` has 30–50 violations and warrants a dedicated documentation sprint with a docstring-convention decision.
- This PR addresses **the Ruff `S` portion of issue #22**. CodeFactor triage stays open as a separate item.

## Test plan
- [x] `uv run ruff check src/ tests/` is clean.
- [x] `uv run ruff format --check src/ tests/` is clean.
- [x] `uv run mypy src/` is clean (94 tests pass).
- [x] `uv run pytest -m "not hardware"` — 94 passed.

Generated with Claude <noreply@anthropic.com>