### PR TITLE
docs: prune stale P2/P3 sections (post-EXP-050 cleanups)

### DIFF
--- a/docs/HARDWARE_MOD.md
+++ b/docs/HARDWARE_MOD.md
@@ -192,12 +192,7 @@ See `examples/volume_control.py` for the complete integration.
 
 ## Cost in context
 
-| Solution | Total cost | Disposable tips | Serial volume control |
-|----------|------------|-----------------|----------------------|
-| **dPette + this mod** | **~$150** | **Yes** | **Yes (A6 + MOSFET)** |
-| INTEGRA VIAFLO + ASSIST stand | ~$4,000+ | Yes | Partial |
-| Opentrons OT-2 (full robot) | ~$10,000+ | Yes | Full API |
-| ac-rad Digital Pipette v2 | ~$200 | No (syringe) | Arduino |
-
-The dPette + MOSFET mod is the only open-source, disposable-tip,
-API-controlled pipette under $200.
+The MOSFET parts add ~€5 (one DEBO LOGIC 4CH board) on top of the
+~$80–130 dPette. See the
+[comparison table in the root README](../README.md#why-this-matters)
+for how this stacks up against commercial liquid handlers.

--- a/docs/PROTOCOL_NOTES.md
+++ b/docs/PROTOCOL_NOTES.md
@@ -299,9 +299,14 @@ FUN_14001af80 (buffered frame parser):
 
 Response timeout: 1000ms per read (`_timerRead->start(1000)`).
 
-## Remote pipetting flow (CONFIRMED — live hardware, 2026-04-06)
+## Remote pipetting flow — initial findings (2026-04-06)
 
-### Pipetting sequence (CONFIRMED — hands-off, no Err4)
+> **Superseded by EXP-050 below.** The flow in this section uses the
+> physical dial for volume because remote volume control had not yet
+> been discovered. Keep for the trace data; for the current correct
+> protocol see "Remote volume control — CONFIRMED (EXP-050)".
+
+### Pipetting sequence (hands-off, no Err4)
 
 Tested on clean dPette 10-100 µL.  Set volume on the physical dial,
 then control aspirate/dispense remotely.
@@ -398,25 +403,18 @@ reclassified as dead ends in EXPERIMENT_LOG.md.
 
 ## Open questions
 
-1. **WriteEE byte layout** — exact mapping of address and value bytes in
-   the 0xA4 packet needs write-then-read confirmation
-2. **0xA3 data flow** — how exactly does the device deliver EEPROM data?
-   May require a specific command sequence (handshake → start → read)
-3. **Err4 prevention** — is there a clean way to enter/exit cal mode
+1. **Err4 prevention** — is there a clean way to enter/exit cal mode
    without triggering Err4?  PetteCali manages this somehow.
-4. **Volume readback** — no command was found to read the current volume
-   setting from the device
-5. **Persistent Err4** — no known way to clear the startup error; persists
+2. **Volume readback** — no command was found to read the current volume
+   setting from the device.
+3. **Persistent Err4** — no known way to clear the startup error; persists
    through PetteCali WriteData, ResetFactory, and the physical factory
-   reset button
+   reset button.
 
 ## Next steps
 
-1. **VM serial capture** — run PetteCali in a Windows VM with serial port
-   logging to capture the exact enter/exit cal mode sequence (may reveal
-   commands that prevent Err4)
-2. **Proper recalibration** — use PetteCali with real weight measurements
+1. **Proper recalibration** — use PetteCali with real weight measurements
    to write correct k/b values (the dummy calibration wrote k=1.2313,
-   b=0.0000 which may affect accuracy)
-3. **Err4 root cause** — deeper analysis of what flag is set and how to
-   clear it without PetteCali
+   b=0.0000 which may affect accuracy).
+2. **Err4 root cause** — deeper analysis of what flag is set and how to
+   clear it without PetteCali.

--- a/docs/SAFETY_MODEL.md
+++ b/docs/SAFETY_MODEL.md
@@ -26,14 +26,7 @@ causing missed steps, position drift, or overheating.
 contiguous-cycle counter (`MAX_CONTIGUOUS_CYCLES = 50`) forces a pause
 so the operator can inspect the device.
 
-### 3. Uncontrolled tip ejection
-
-Ejecting a tip while liquid is present could spray hazardous material.
-
-**Mitigation:** (future) sequence checks — warn or block `eject_tip()`
-if the last operation was `aspirate()` without a corresponding `dispense()`.
-
-### 4. Unknown command side-effects
+### 3. Unknown command side-effects
 
 Sending arbitrary bytes to the pipette could trigger undocumented
 factory or debug modes.
@@ -43,7 +36,7 @@ factory or debug modes.
 hand-crafted bytes are reserved for `tools/` scripts used during
 reverse-engineering.
 
-### 5. Calibration mode entry causes persistent Err4
+### 4. Calibration mode entry causes persistent Err4
 
 Sending `A5 b2=1` (enter calibration mode) sets a persistent flag
 that causes Err4 on every subsequent reboot.  This was confirmed on
@@ -56,7 +49,7 @@ method uses only `A5 b2=0` (handshake) and `B0 b2=1` (prime).
 The `Command.HANDSHAKE` with `b2=1` is intentionally not exposed
 as a high-level method.
 
-### 6. EEPROM writes can break motor control
+### 5. EEPROM writes can break motor control
 
 Writing incorrect calibration values (k/b coefficients) to EEPROM
 via `A4` can cause the motor to refuse aspirate/dispense commands.


### PR DESCRIPTION
## Summary
Doc-only cleanups for items the audit flagged as stale after EXP-050:

- **`docs/PROTOCOL_NOTES.md`** — drop two answered Open questions (WriteEE byte layout, 0xA3 data flow — both confirmed via EXP-031 above in the same file). Drop the "VM serial capture" Next step (done). Label the pre-EXP-050 "Remote pipetting flow" section as historical, pointing readers at the EXP-050 section below which has the corrected protocol.
- **`docs/HARDWARE_MOD.md`** — replace the stale "Cost in context" mini-table ($150 / "only API-controlled pipette under $200") with a one-liner pointing at the README comparison table.
- **`docs/SAFETY_MODEL.md`** — drop risk #3 ("Uncontrolled tip ejection") — mitigation referenced a future `eject_tip()` function that doesn't exist in the codebase. Renumber subsequent risks.

The audit also flagged `CONTRIBUTING.md` "Makefile drift" but on inspection the targets (`make test`, `make lint`, `make all`) **do** exist in the Makefile, so no change is needed there.

## Test plan
- [x] `markdownlint-cli2` on README + AGENTS + CONTRIBUTING + docs + .claude/rules — 0 errors.
- [ ] Cross-check that referenced sections (README "Why this matters", PROTOCOL_NOTES "Remote volume control — EXP-050") still exist after the merge.

Generated with Claude <noreply@anthropic.com>