### PR TITLE
docs(overview): add boundary failure-policy table

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -83,3 +83,34 @@ driver.py  →  serial_link.py  →  pyserial
 
 `protocol.py` must **never** import `driver` or `safety`.
 `serial_link.py` must **never** import `protocol` or `driver`.
+
+## Boundary failure-policy
+
+Every I/O or external boundary in `src/dpette/` is pinned to exactly one of
+three policies:
+
+- **fail-loud** — raise immediately; failure is a programmer / hardware /
+  config problem that silent degradation would hide.
+- **wrap-degrade** — catch a specific exception, log a warning, return a
+  degraded result.
+- **wrap-continue** — wrap-degrade inside a loop; per-item failure must
+  not abort the batch.
+
+| Boundary | Location | Policy | Notes |
+|---|---|---|---|
+| Serial port open | `serial_link.SerialLink.open` | fail-loud | `SerialException` propagates — no port means no link; silent continuation would deceive the caller. |
+| Serial write / flush | `serial_link.SerialLink.write` | fail-loud | Unacknowledged writes mean a command was never sent; swallowing skips a pipetting step. |
+| Serial read (short) | `serial_link.SerialLink.read` | fail-loud | Returns the short bytes; caller (`_transact`) checks length and raises `TimeoutError`. |
+| KEY completion read timeout | `driver._key_command` | **fail-loud (change needed)** | Currently logs a warning and returns the ACK packet as if the motion completed; that masks an unknown motor state. PR δ. |
+| Volume / speed validation | `safety.validate_volume`, `safety.validate_speed` | fail-loud | Raises `SafetyError` on out-of-range input. Silent clamping would deliver the wrong volume. |
+| Packet encode — byte overflow | `protocol.encode_packet` | **fail-loud (change needed)** | Currently truncates byte values >255 silently; an oversized integer becomes an unintended command byte. PR δ. |
+| Packet decode — wrong length / header | `protocol.decode_packet` | fail-loud | Raises `ValueError`; malformed frames indicate noise or protocol mismatch. |
+| Packet decode — checksum mismatch | `protocol.decode_packet` | fail-loud | Raises `ValueError`; bad checksum means the bytes can't confirm any motion. |
+| Transact timeout | `driver._transact` | fail-loud | Raises `TimeoutError` when fewer than 6 bytes are received. |
+| `connect()` exception catch-all | `driver.DPetteDriver.connect` | wrap-degrade | Catches `OSError` / `TimeoutError` / `RuntimeError`, enters stub mode for CI/simulation. A `strict=True` opt-out for lab callers is tracked alongside PR δ. |
+| Cycle-count overrun | `driver._check_cycle_limit` | fail-loud | Raises `RuntimeError` after `MAX_CONTIGUOUS_CYCLES` (50) — cumulative mechanical abuse must not be ignorable. |
+| Log file handler creation | `logging_utils.get_logger` | **wrap-degrade (change needed)** | Currently lets `OSError` propagate if the log dir is unwritable; should fall back to console-only logging. PR δ. |
+| Port discovery returns `None` | `config.guess_default_port` (at call sites) | fail-loud at call site | The function is intentionally nullable; callers must assert non-None with a readable message before passing it to `SerialConfig`. |
+
+The three rows tagged *(change needed)* describe known gaps tracked in
+a separate PR; everything else matches the recommended policy today.


### PR DESCRIPTION
## Summary
Adds a new **Boundary failure-policy** section to `docs/OVERVIEW.md`. Every I/O or external boundary in `src/dpette/` is pinned to one of three policies: **fail-loud / wrap-degrade / wrap-continue** (per `py-harden-ruff.md` §5).

13 boundaries enumerated, 10 already match the recommended policy. The three tagged **(change needed)** are known behaviour gaps that PR δ will close:

1. `driver._key_command` — logs a warning and returns the ACK packet when the completion packet is missing; should fail-loud (unknown motor state).
2. `protocol.encode_packet` — silently truncates byte values >255; should range-check.
3. `logging_utils.get_logger` — lets `OSError` propagate if the log dir is unwritable; should wrap-degrade to console-only.

## Test plan
- [x] `markdownlint-cli2 docs/OVERVIEW.md` — 0 errors.
- [ ] On GitHub, table renders with 13 rows + the three change-needed rows visibly tagged.
- [ ] PR δ (next) implements the three changes and updates the table to drop the *(change needed)* labels.

Generated with Claude <noreply@anthropic.com>