### PR TITLE
docs(readme): correct overstated Acknowledgments claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,16 @@ reference.
 
 ## Acknowledgments
 
-The official DLAB serial protocol document (`Communication_Protocol_CN.doc`)
-was found in [xg590/Learn_dPettePlus](https://github.com/xg590/Learn_dPettePlus)
-by Xiaokang Guo (NYU). This document was the key to discovering the remote
-control protocol (A0/B0/B2/B3) that enabled serial volume control — the
-single biggest breakthrough in this project.
+[Xiaokang Guo (NYU)](https://github.com/xg590) had already reverse-engineered
+the dPette+ in [xg590/Learn_dPettePlus](https://github.com/xg590/Learn_dPettePlus)
+and republished the DLAB `Communication_Protocol_CN.doc` there. We came across
+the spec while cross-checking our own findings; it confirms several of our
+results — most usefully the A1 INFO response layout (channel count, volume
+range) and the B3 KEY completion-code semantics.
+
+The remote-control protocol itself (A0/B0/B2/B3) was discovered earlier in
+this project by Ghidra-decompiling `PetteCali.exe` and confirmed in live
+experiments EXP-049 and EXP-050.
 
 ## License
 


### PR DESCRIPTION
## Summary
The Acknowledgments paragraph credited xg590's republished DLAB spec as "the key to discovering the remote control protocol (A0/B0/B2/B3)". That is not what happened.

**Actual timeline**:
1. Ghidra decompilation of `PetteCali.exe` → command bytes, packet format, checksum algorithm.
2. EXP-049 / EXP-050 live probing → confirmed remote-control protocol (A0/B0/B2/B3) and B2 volume control.
3. Only later did we cross-check against `Communication_Protocol_CN.doc` in `xg590/Learn_dPettePlus` — which confirmed several findings (A1 layout, B3 completion codes) but didn't source the original discovery.

Rewrites the paragraph to credit the prior work honestly: useful for cross-checking and confirming issues #37 (A1 INFO layout) and #38 (B3 completion-code semantics), but not the "single biggest breakthrough" of the project.

## Test plan
- [x] `markdownlint-cli2 README.md` — 0 errors.
- [ ] On GitHub, the Acknowledgments section renders the corrected language.

Generated with Claude <noreply@anthropic.com>