### PR TITLE
docs: update test count

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ not discrete pipette volumes, so they solve a different problem.*
 - **Mixing** — aspirate/dispense cycling with caller-controlled tip position
 - **EEPROM read/write** — firmware version, calibration coefficients
 - **Single- and multichannel** — verified on the 8-channel dPette
-- 94 tests passing, 55 experiments documented
+- 121 tests passing, 55 experiments documented
 
 ## Quickstart
 
@@ -141,7 +141,7 @@ drv.set_speed(KeyAction.BLOW, 1)  # slow dispense
 ### Run tests (no hardware needed)
 
 ```bash
-pytest                  # 94 tests
+pytest                  # 121 tests
 ruff check src/ tests/  # lint
 mypy src/               # type check
 ```


### PR DESCRIPTION
## Summary

- Documentation-only reconciliation between the repository and its current code/configuration.
- Review gate: documentation updates only; `make validate` was not invoked per the user request to skip the pre-push gate for docs-only changes.

## Commits

- 2b1e8a7 docs: update test count

## Notes

For Lambda-Biolab repositories, the org profile notes that qte77 is a former collaborator; remaining qte77 references in this repository are historical, attribution, or upstream metadata.