### PR TITLE
chore(ci): fix stale version comments on actions/checkout pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0

--- a/.github/workflows/generate-sbom.yaml
+++ b/.github/workflows/generate-sbom.yaml
@@ -15,7 +15,7 @@ jobs:
   generate-sbom:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - uses: qte77/gha-sbom-action@cd873b1278a6793a99cfe199c01d603d72cca717  # v0.1.1
         with:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Lychee link check
         id: lychee


### PR DESCRIPTION
Follow-up to #70.

After bumping `actions/checkout` to v7.0.1 in #70, three workflow files still carried a `# v6` trailing comment that no longer matched the pinned SHA. `codeql.yml` was updated as part of #70; align the others.

## Changes

- `.github/workflows/ci.yml` — `# v6` → `# v7.0.1`
- `.github/workflows/generate-sbom.yaml` — `# v6` → `# v7.0.1`
- `.github/workflows/links.yml` — `# v6` → `# v7.0.1`

No SHA changes; comments only.

## Out-of-band

Renamed the `github_actions` repo label → `github-actions` (with hyphen) so the `labels: "github-actions"` reference in `.github/dependabot.yml` resolves. No config change needed.