### PR TITLE
ci: bump link checker reusable workflow SHA to b063c56

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   check-links:
-    uses: Lambda-Biolab/.github-private/.github/workflows/links.yml@d82b41c33d124b96cf20cf998c6c9c673e15b40e
+    uses: Lambda-Biolab/.github-private/.github/workflows/links.yml@b063c56


### PR DESCRIPTION
Bump reusable workflow SHA to the fixed commit (removes a `secrets: inherit: true` block that was making the workflow unreachable).