### PR TITLE
fix(ci): codeql MUST run on every PR — add `pull_request` trigger

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,9 +4,19 @@ name: "CodeQL"
 
 on:
   push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   schedule:
     - cron: '27 11 * * 0'
   workflow_dispatch:
+
+# CodeQL MUST run on every PR so security findings block the
+# merge instead of showing up post-merge. The "merge-ref SHA race
+# with merge-protection check" concern applied to a top-level
+# pull_request trigger on a reusable workflow (pre-2023 behavior),
+# not to this file's own trigger. Mirroring the org rule documented
+# in antomicblitz/opencode-config/templates/python-repo/.github/workflows/ci.yml.
 
 jobs:
   analyze:


### PR DESCRIPTION
The `if: github.event_name != 'pull_request'` on the codeql job downgraded
CodeQL to a post-merge advisory: a vulnerability surfaced ONLY after the
code was already on `main` and the branch-protection check (had it been
configured) had no chance to block the merge.

The "merge-ref SHA race" concern that the old comment cited does NOT apply
to a `pull_request` trigger on the workflow's own `on:` block — only to a
top-level `pull_request` trigger on a reusable workflow (pre-2023 GitHub
Actions behavior). The triggers in the workflow header already declare
`pull_request: branches: [main]`; the `if:` filter was actively fighting them.

Mirrors the org rule documented in
antomicblitz/opencode-config/templates/python-repo/.github/workflows/ci.yml
(see opencode-config#57).
